### PR TITLE
设置在重新打开项目前不生效

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/gui/chat/ChatCodingPanel.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/gui/chat/ChatCodingPanel.kt
@@ -205,11 +205,13 @@ class ChatCodingPanel(private val chatCodingService: ChatCodingService, val disp
         myList.add(messageView)
 
         var text = ""
-        content.collect {
-            text += it
-            messageView.updateSourceContent(text)
-            messageView.updateContent(text)
-            messageView.scrollToBottom()
+        runCatching {
+            content.collect {
+                text += it
+                messageView.updateSourceContent(text)
+                messageView.updateContent(text)
+                messageView.scrollToBottom()
+            }
         }
 
         messageView.reRenderAssistantOutput()


### PR DESCRIPTION
fix: openai setting change not affect in same project lifecycle 

fix: chat window loading will not be remove after request failed (for example openAI key invalid)