### PR TITLE
fix: potential IndexOutOfBoundsException when streaming response

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/llms/openai/OpenAIProvider.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/llms/openai/OpenAIProvider.kt
@@ -99,9 +99,11 @@ class OpenAIProvider(val project: Project) : LLMProvider {
                         trySend(error.message ?: "Error occurs")
                     }
                     .blockingForEach { response ->
-                        val completion = response.choices[0].message
-                        if (completion != null && completion.content != null) {
-                            trySend(completion.content)
+                        if (response.choices.isNotEmpty()) {
+                            val completion = response.choices[0].message
+                            if (completion != null && completion.content != null) {
+                                trySend(completion.content)
+                            }
                         }
                     }
 


### PR DESCRIPTION
这个 PR 修复了使用 [one-api](https://github.com/songquanpeng/one-api) 作为 openai 代理时，获取响应内容引发数组越界异常，导致 auto-dev 对话无任何回应的问题

![image](https://github.com/unit-mesh/auto-dev/assets/21141423/6bc79012-b4f1-414c-94ac-b090bfa5ae0f)


（可能是第三方实现差异？）[one-api](https://github.com/songquanpeng/one-api)  `/v1/chat/completions` 接口返回的首个 data 的 `choices` 会是空数组，这里简单对 `choices` 做一次判空以修复上述问题

```json5
data: {"id":"","object":"","created":0,"model":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}],"choices":[],"usage":null}

data: {"id":"chatcmpl-8Hl0aqEW4rt8jwDBQow9VAzU43pqB","object":"chat.completion.chunk","created":1699242968,"model":"gpt-35-turbo","choices":[{"index":0,"finish_reason":null,"delta":{"role":"assistant"},"content_filter_results":{}}],"usage":null}

// more data...

data: [DONE]

```