### PR TITLE
fix: use SupervisorJob to prevent coroutine scope being cancel in all project lifetime

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/util/LLMCoroutineScope.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/util/LLMCoroutineScope.kt
@@ -2,13 +2,16 @@ package cc.unitmesh.devti.util
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
+val logger = Logger.getInstance(LLMCoroutineScope::class.java)
+
 val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-    throwable.printStackTrace()
+    logger.error(throwable)
 }
 
 @Service(Service.Level.PROJECT)

--- a/src/main/kotlin/cc/unitmesh/devti/util/LLMCoroutineScope.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/util/LLMCoroutineScope.kt
@@ -3,11 +3,16 @@ package cc.unitmesh.devti.util
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.SupervisorJob
+
+val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+    throwable.printStackTrace()
+}
 
 @Service(Service.Level.PROJECT)
-class LLMCoroutineScope(val coroutineScope: CoroutineScope = CoroutineScope(EmptyCoroutineContext)) {
+class LLMCoroutineScope(val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + coroutineExceptionHandler)){
     companion object {
         fun scope(project: Project): CoroutineScope = project.service<LLMCoroutineScope>().coroutineScope
     }


### PR DESCRIPTION
遇到过无任何出错提示，但对话不执行的情况。未能复现，但从 review 的代码看， 之前所用的 scope 是 EmptyContext，如果某个  coroutine 因异常退出而未被捕获，那会导致此 scope 被 cancel