### PR TITLE
docs: fix typo in custom-test-template.md

### DIFF
--- a/docs/customize/custom-test-template.md
+++ b/docs/customize/custom-test-template.md
@@ -7,7 +7,7 @@ nav_order: 15
 
 Create template files under `prompts/templates` directory, like:
 
-- Java langauge: `ControllerTest.java`, `ServiceTest.java`, `Test.java`
+- Java language: `ControllerTest.java`, `ServiceTest.java`, `Test.java`
 - Kotlin language: `ControllerTest.kt`, `ServiceTest.kt`, `Test.kt`
 
 when generate test file, will use these templates.


### PR DESCRIPTION
langauge -> language