### PR TITLE
fix : if subfolder exists, createChildDirectory() will throw "xxx alr…

### DIFF
--- a/exts/devins-lang/src/main/kotlin/cc/unitmesh/devti/language/compiler/exec/WriteInsCommand.kt
+++ b/exts/devins-lang/src/main/kotlin/cc/unitmesh/devti/language/compiler/exec/WriteInsCommand.kt
@@ -39,7 +39,14 @@ class WriteInsCommand(val myProject: Project, val argument: String, val content:
                     parentDir = projectDir
                     for (dir in parentDirs) {
                         if (dir.isEmpty()) continue
-                        parentDir = runWriteAction { parentDir?.createChildDirectory(this, dir) }
+                        
+                        //check child folder if exist? if not, create it
+                        if(parentDir?.findChild(dir) == null) {
+                            parentDir = runWriteAction { parentDir?.createChildDirectory(this, dir) }
+                        }
+                        else {
+                            parentDir = parentDir?.findChild(dir)
+                        }
                     }
 
                     if (parentDir == null) {


### PR DESCRIPTION
當初我的測試不完整，只測試了檔案有沒有存在的情境，沒有測試多層資料夾是否存在的情境
如果路徑是 a/b/c/xxx.txt，如果 a 資料夾存在，createChildDirectory() 會出現 "already exists in VFS"的錯誤
嘗試修正該問題，測試結果: 獨立devin檔案以及對話視窗都正常產生資料夾+檔案

