### PR TITLE
bugfix：修复解决需要重启才能刷新Custom Engine Prompt(Json) 配置问题

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/custom/variable/SpecResolverService.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/custom/variable/SpecResolverService.kt
@@ -9,9 +9,7 @@ import com.intellij.openapi.components.Service
  */
 @Service(Service.Level.APP)
 class SpecResolverService {
-    private val specs = CustomPromptConfig.load().spec
-
-    fun resolvers(): List<SpecVariableResolver> = specs.map { (key, value) ->
+    fun resolvers(): List<SpecVariableResolver> = CustomPromptConfig.load().spec.map { (key, value) ->
         SpecVariableResolver("SPEC_$key", value)
     }
 


### PR DESCRIPTION
 问题点：在idea配置中，修改setting文件中的Custom Engine Prompt(Json) 的内容后，重新发起Chat与模型沟通时，并未更新最新的JSON内容，需要重启IDEA，才可以重新加载。
修复后：可以更新JSON内容后，实时加载最新的JSON内容，解决需要重启才能刷新配置问题