### PR TITLE
feat: 增加新特性，可以正则过滤编辑器选中的内容，提问内容更加精简，明确

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/custom/CustomActionBaseIntention.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/custom/CustomActionBaseIntention.kt
@@ -46,7 +46,7 @@ class CustomActionBaseIntention(private val intentionConfig: CustomIntentionConf
         val afterCursor = editor.document.text.substring(editor.caretModel.offset)
 
         val prompt: CustomIntentionPrompt = constructCustomPrompt(
-            psiElement!!, selectedText,
+            psiElement!!, findAllMatches(selectedText, intentionConfig.selectedRegex),
             beforeCursor, afterCursor
         )
 
@@ -65,6 +65,20 @@ class CustomActionBaseIntention(private val intentionConfig: CustomIntentionConf
                 panel.setInput(prompt.displayPrompt)
             }
         }
+    }
+
+    private fun findAllMatches(input: String, regex: String): String {
+        if (regex == "") return input
+        if (input = "") return input
+        val builder = StringBuilder()
+        val pattern = Pattern.compile(regex)
+        val matcher = pattern.matcher(input)
+
+        while (matcher.find()) {
+            builder.append(matcher.group()).append("\n")
+        }
+
+        return builder.toString()
     }
 
     private fun constructCustomPrompt(

--- a/src/main/kotlin/cc/unitmesh/devti/custom/action/CustomIntentionConfig.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/custom/action/CustomIntentionConfig.kt
@@ -10,4 +10,5 @@ class CustomIntentionConfig {
     var template: String = ""
     val isBuiltIn: Boolean = false
     val priority: Int = 0
+    var selectedRegex: String = ""
 }


### PR DESCRIPTION
需求开发背景：我有一个提示词模板，但是相关的代码，在整个代码文件中，存在于多处，我不希望把所有的代码都一并上传，让大模型进行分析，那样提供的信息太多太杂，大模型分析的结果往往会受到干扰，生成的结果并不完美，因此我想考虑在选中内容时，有一个正则工具对提问的选择内容进行提前筛洗。
特性功能：在AutoDev的Custome Engine Prompt(Json) 中，属性：prompts 属性中， 增加属性：selectedRegex， 此属性表示标准正则表达式内容，用于在将选中的编辑器内容，进行正则匹配，将匹配的内容，筛选出来，如果有多个匹配符合，则会用 \n 隔开， 最后将匹配的内容，给予至模型调用方法