### PR TITLE
fix: wrong trigger when user typing from code.

### DIFF
--- a/src/main/kotlin/cc/unitmesh/devti/practise/RenameLookupManagerListener.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/practise/RenameLookupManagerListener.kt
@@ -8,6 +8,7 @@ import cc.unitmesh.devti.util.LLMCoroutineScope
 import com.intellij.codeInsight.completion.PrefixMatcher
 import com.intellij.codeInsight.lookup.*
 import com.intellij.codeInsight.lookup.impl.LookupImpl
+import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
@@ -35,6 +36,9 @@ class RenameLookupManagerListener(val project: Project) : LookupManagerListener 
 
         // maybe user just typing, we should handle for this
         val originName = (targetElement as? PsiNameIdentifierOwner)?.name ?: return
+
+        // avoid user typing in template. only suggest that user refactor the name
+        TemplateManager.getInstance(project).getActiveTemplate(editor) ?: return
 
         if (originName.isBlank()) return
 


### PR DESCRIPTION
```kotlin
 override fun activeLookupChanged(oldLookup: Lookup?, newLookup: Lookup?) {
        if (!project.coderSetting.state.enableRenameSuggestion) return

        val lookupImpl = newLookup as? LookupImpl ?: return
        val editor = lookupImpl.editor as? EditorEx ?: return
        val targetElement: PsiElement = lookupElement(lookupImpl, editor) ?: return

        // maybe user just typing, we should handle for this
        val originName = (targetElement as? PsiNameIdentifierOwner)?.name ?: return

        if (originName.isBlank()) return

        val promptText =
            "$originName is a badname. Please provide 5 better options name for follow code: \n```${targetElement.language.displayName}\n${targetElement.text}\n```\n\n1."

        try {
            doExecuteNameSuggest(promptText, lookupImpl)
            logger.warn("will trigger when typing from java code") // ======= Note here =========
        } catch (e: Exception) {
            logger.warn("Error in RenameLookupManagerListener", e)
        }
    }
    override fun activeLookupChanged(oldLookup: Lookup?, newLookup: Lookup?) {
        if (!project.coderSetting.state.enableRenameSuggestion) return

        val lookupImpl = newLookup as? LookupImpl ?: return
        val editor = lookupImpl.editor as? EditorEx ?: return
        val targetElement: PsiElement = lookupElement(lookupImpl, editor) ?: return

        // maybe user just typing, we should handle for this
        val originName = (targetElement as? PsiNameIdentifierOwner)?.name ?: return

        // avoid user typing in template. only suggest that user refactor the name
        TemplateManager.getInstance(project).getActiveTemplate(editor) ?: return

        if (originName.isBlank()) return

        val promptText =
            "$originName is a badname. Please provide 5 better options name for follow code: \n```${targetElement.language.displayName}\n${targetElement.text}\n```\n\n1."

        try {
            doExecuteNameSuggest(promptText, lookupImpl)
            logger.warn("will trigger when typing from java code")
        } catch (e: Exception) {
            logger.warn("Error in RenameLookupManagerListener", e)
        }
    }
```

fixed by 
```kotlin
      // avoid user typing in template. only suggest that user refactor the name
        TemplateManager.getInstance(project).getActiveTemplate(editor) ?: return
```