### PR TITLE
refactor: Add the right-click actions to the dynamic group and check …

### DIFF
--- a/src/222/main/kotlin/cc/unitmesh/devti/intentions/IntentionHelperUtil.kt
+++ b/src/222/main/kotlin/cc/unitmesh/devti/intentions/IntentionHelperUtil.kt
@@ -16,7 +16,7 @@ import com.intellij.psi.PsiFile
 
 object IntentionHelperUtil {
     val EP_NAME: ExtensionPointName<IntentionActionBean> = ExtensionPointName("cc.unitmesh.autoDevIntention")
-    fun getAiAssistantIntentions(project: Project, editor: Editor, file: PsiFile): List<IntentionAction> {
+    fun getAiAssistantIntentions(project: Project, editor: Editor?, file: PsiFile): List<IntentionAction> {
         val extensionList = EP_NAME.extensionList
 
         val builtinIntentions = extensionList

--- a/src/222/main/resources/META-INF/autodev-core.xml
+++ b/src/222/main/resources/META-INF/autodev-core.xml
@@ -238,8 +238,8 @@
         </group>
 
         <!-- For right click -->
-        <!-- TODO: refactor to dynamic group: https://plugins.jetbrains.com/docs/intellij/grouping-action.html#adding-child-actions-to-the-dynamic-group -->
-        <group id="org.intellij.sdk.action.GroupedActions" popup="true" text="AutoDev Chat" description="AutoDev chat">
+        <group id="autodev.groups.AutoChatDynamicActionGroup" popup="true" description="AutoDev chat"
+               class="cc.unitmesh.devti.actions.groups.AutoChatDynamicActionGroup">
             <action id="cc.unitmesh.devti.actions.chat.ExplainThisAction"
                     class="cc.unitmesh.devti.actions.chat.ExplainThisAction"
                     description="Ask AI about this code">

--- a/src/233/main/kotlin/cc/unitmesh/devti/intentions/IntentionHelperUtil.kt
+++ b/src/233/main/kotlin/cc/unitmesh/devti/intentions/IntentionHelperUtil.kt
@@ -16,7 +16,7 @@ import com.intellij.psi.PsiFile
 
 object IntentionHelperUtil {
     val EP_NAME: ExtensionPointName<IntentionActionBean> = ExtensionPointName("cc.unitmesh.autoDevIntention")
-    fun getAiAssistantIntentions(project: Project, editor: Editor, file: PsiFile): List<IntentionAction> {
+    fun getAiAssistantIntentions(project: Project, editor: Editor?, file: PsiFile): List<IntentionAction> {
         val extensionList = EP_NAME.extensionList
 
         val builtinIntentions = extensionList

--- a/src/233/main/resources/META-INF/autodev-core.xml
+++ b/src/233/main/resources/META-INF/autodev-core.xml
@@ -251,8 +251,8 @@
         </group>
 
         <!-- For right click -->
-        <!-- TODO: refactor to dynamic group: https://plugins.jetbrains.com/docs/intellij/grouping-action.html#adding-child-actions-to-the-dynamic-group -->
-        <group id="org.intellij.sdk.action.GroupedActions" popup="true" text="AutoDev Chat" description="AutoDev chat">
+        <group id="autodev.groups.AutoChatDynamicActionGroup" popup="true" description="AutoDev chat"
+               class="cc.unitmesh.devti.actions.groups.AutoChatDynamicActionGroup">
             <action id="cc.unitmesh.devti.actions.chat.ExplainThisAction"
                     class="cc.unitmesh.devti.actions.chat.ExplainThisAction"
                     description="Ask AI about this code">

--- a/src/main/kotlin/cc/unitmesh/devti/actions/chat/ChatWithThisAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/chat/ChatWithThisAction.kt
@@ -1,6 +1,6 @@
 package cc.unitmesh.devti.actions.chat
 
-import cc.unitmesh.devti.actions.chat.base.ChatBaseAction
+import cc.unitmesh.devti.actions.chat.base.ChatCheckForUpdateAction
 import cc.unitmesh.devti.gui.chat.ChatActionType
 import cc.unitmesh.devti.gui.sendToChatWindow
 import cc.unitmesh.devti.settings.LanguageChangedCallback.presentationText
@@ -8,7 +8,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.temporary.getElementToAction
 
-class ChatWithThisAction : ChatBaseAction() {
+class ChatWithThisAction : ChatCheckForUpdateAction() {
 
     init{
         presentationText("settings.autodev.rightClick.chat", templatePresentation)

--- a/src/main/kotlin/cc/unitmesh/devti/actions/chat/ExplainThisAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/chat/ExplainThisAction.kt
@@ -1,10 +1,10 @@
 package cc.unitmesh.devti.actions.chat
 
-import cc.unitmesh.devti.actions.chat.base.ChatBaseAction
+import cc.unitmesh.devti.actions.chat.base.ChatCheckForUpdateAction
 import cc.unitmesh.devti.gui.chat.ChatActionType
 import cc.unitmesh.devti.settings.LanguageChangedCallback.presentationText
 
-class ExplainThisAction() : ChatBaseAction() {
+class ExplainThisAction() : ChatCheckForUpdateAction() {
     init{
         presentationText("settings.autodev.rightClick.explain", templatePresentation)
     }

--- a/src/main/kotlin/cc/unitmesh/devti/actions/chat/GenerateApiTestAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/chat/GenerateApiTestAction.kt
@@ -1,13 +1,13 @@
 package cc.unitmesh.devti.actions.chat
 
-import cc.unitmesh.devti.actions.chat.base.ChatBaseAction
+import cc.unitmesh.devti.actions.chat.base.ChatCheckForUpdateAction
 import cc.unitmesh.devti.gui.chat.ChatActionType
 import cc.unitmesh.devti.settings.LanguageChangedCallback.presentationText
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 
-class GenerateApiTestAction : ChatBaseAction() {
+class GenerateApiTestAction : ChatCheckForUpdateAction() {
     init {
         presentationText("settings.autodev.rightClick.genApiTest", templatePresentation)
     }

--- a/src/main/kotlin/cc/unitmesh/devti/actions/chat/RefactorThisAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/chat/RefactorThisAction.kt
@@ -1,39 +1,29 @@
 package cc.unitmesh.devti.actions.chat
 
 import cc.unitmesh.devti.AutoDevBundle
-import cc.unitmesh.devti.actions.chat.base.ChatBaseAction
+import cc.unitmesh.devti.actions.chat.base.ChatCheckForUpdateAction
 import cc.unitmesh.devti.actions.chat.base.collectProblems
 import cc.unitmesh.devti.actions.chat.base.commentPrefix
 import cc.unitmesh.devti.gui.chat.ChatActionType
 import cc.unitmesh.devti.gui.chat.ChatCodingPanel
 import cc.unitmesh.devti.provider.RefactoringTool
 import cc.unitmesh.devti.settings.LanguageChangedCallback.presentationText
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 
-open class RefactorThisAction : ChatBaseAction() {
+open class RefactorThisAction : ChatCheckForUpdateAction() {
     init {
         presentationText("settings.autodev.rightClick.refactor", templatePresentation)
     }
 
-    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
     override fun getActionType(): ChatActionType = ChatActionType.REFACTOR
     override fun update(e: AnActionEvent) {
-        val editor = e.getData(CommonDataKeys.EDITOR)
         val file = e.getData(CommonDataKeys.PSI_FILE)
-        val project = e.getData(CommonDataKeys.PROJECT)
-
-        if (editor == null || file == null || project == null) {
-            e.presentation.isEnabled = false
-            return
-        }
-
-        if (file.isWritable) {
-            e.presentation.isEnabled = true
+        if (file != null && file.isWritable) {
+            super.update(e)
             return
         }
 

--- a/src/main/kotlin/cc/unitmesh/devti/actions/chat/base/ChatCheckForUpdateAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/chat/base/ChatCheckForUpdateAction.kt
@@ -1,0 +1,28 @@
+package cc.unitmesh.devti.actions.chat.base
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.temporary.getElementToAction
+
+/**
+ * This abstract class can check for the psi-element
+ * when updating the presentation of the action in the user interface.
+ *
+ * For example, when the psi-element of an action is [PsiWhiteSpace],
+ * an unexpected prompt is generated and should not be processed.
+ * To avoid such prompts, the action should be disabled.
+ *
+ * @author lk
+ */
+abstract class ChatCheckForUpdateAction : ChatBaseAction() {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val project = e.getData(CommonDataKeys.PROJECT)
+        e.presentation.isEnabled = getElementToAction(project, editor)?.text?.isNotBlank() ?: false
+    }
+}

--- a/src/main/kotlin/cc/unitmesh/devti/actions/groups/AutoChatDynamicActionGroup.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/groups/AutoChatDynamicActionGroup.kt
@@ -1,0 +1,31 @@
+package cc.unitmesh.devti.actions.groups
+
+import cc.unitmesh.devti.settings.LanguageChangedCallback
+import com.intellij.openapi.actionSystem.ActionGroupUtil
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.project.DumbAware
+
+/**
+ * Add the right-click actions to the dynamic group.
+ *
+ * This group hides itself on the editorPopupMenu
+ * when each child are disabled or invisible.
+ *
+ * @author lk
+ */
+class AutoChatDynamicActionGroup : DefaultActionGroup(), DumbAware {
+
+    init {
+        LanguageChangedCallback.presentationText("autodev.chat",
+            templatePresentation.also { it.isHideGroupIfEmpty = true })
+    }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = !ActionGroupUtil.isGroupEmpty(this, e)
+    }
+}
+

--- a/src/main/kotlin/cc/unitmesh/devti/actions/quick/QuickAssistantAction.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/actions/quick/QuickAssistantAction.kt
@@ -37,6 +37,13 @@ open class QuickAssistantAction : AnAction() {
         presentationText("settings.autodev.others.quickAssistant", templatePresentation)
     }
 
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.getData(CommonDataKeys.PSI_FILE)?.isWritable ?: false
+    }
+
+
     override fun actionPerformed(e: AnActionEvent) {
         val dataContext = e.dataContext
         val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return

--- a/src/main/kotlin/cc/unitmesh/devti/intentions/AutoDevIntentionHelper.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/intentions/AutoDevIntentionHelper.kt
@@ -22,6 +22,7 @@ class AutoDevIntentionHelper : IntentionAction, Iconable {
 
         val instance = InjectedLanguageManager.getInstance(project)
         return instance.getTopLevelFile(file)?.virtualFile != null
+                && IntentionHelperUtil.getAiAssistantIntentions(project, editor, file).isNotEmpty()
     }
 
     override fun invoke(project: Project, editor: Editor, file: PsiFile) {

--- a/src/main/kotlin/cc/unitmesh/devti/intentions/IntentionsActionGroup.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/intentions/IntentionsActionGroup.kt
@@ -11,8 +11,9 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import java.util.function.Supplier
 
-class IntentionsActionGroup : ActionGroup(AutoDevBundle.message("intentions.assistant.name"), true), DumbAware {
+class IntentionsActionGroup : ActionGroup(Supplier { AutoDevBundle.message("intentions.assistant.name") }, true), DumbAware {
     override fun getChildren(e: AnActionEvent?): Array<AnAction> {
         val project: Project = e?.project ?: return emptyArray()
         val editor: Editor = e.getData(CommonDataKeys.EDITOR) ?: return emptyArray()

--- a/src/main/kotlin/cc/unitmesh/devti/intentions/action/AutoTestThisIntention.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/intentions/action/AutoTestThisIntention.kt
@@ -21,7 +21,7 @@ class AutoTestThisIntention : ChatBaseIntention() {
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
         val psiElement = file?.originalElement ?: return false
         val service = AutoTestService.context(psiElement)
-        return service != null
+        return service != null && getElementToAction(project, editor)?.text?.isNotBlank() ?: false
     }
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {

--- a/src/main/kotlin/cc/unitmesh/devti/intentions/action/DefaultDocumentationBaseIntention.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/intentions/action/DefaultDocumentationBaseIntention.kt
@@ -7,6 +7,7 @@ import cc.unitmesh.devti.provider.LivingDocumentation
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiUtilBase
 
 class DefaultDocumentationBaseIntention: BasedDocumentationBaseIntention() {
     override val config: CustomDocumentationConfig = CustomDocumentationConfig.default()
@@ -16,9 +17,12 @@ class DefaultDocumentationBaseIntention: BasedDocumentationBaseIntention() {
     override fun getFamilyName(): String = AutoDevBundle.message("intentions.living.documentation.family.name")
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
-        if (editor == null || file == null) return false
+        if (editor == null || file == null || !file.isWritable) return false
 
-        val livingDocumentation = LivingDocumentation.forLanguage(file.language)
-        return livingDocumentation != null
+        return LivingDocumentation.forLanguage(file.language)?.let {
+            editor.selectionModel.selectedText != null || PsiUtilBase.getElementAtCaret(editor)?.run {
+                it.findNearestDocumentationTarget(this) != null
+            } ?: false
+        } ?: false
     }
 }

--- a/src/main/kotlin/cc/unitmesh/devti/intentions/action/NewChatWithCodeBaseIntention.kt
+++ b/src/main/kotlin/cc/unitmesh/devti/intentions/action/NewChatWithCodeBaseIntention.kt
@@ -17,7 +17,7 @@ class NewChatWithCodeBaseIntention : ChatBaseIntention() {
     override fun getFamilyName(): String = AutoDevBundle.message("intentions.chat.new.family.name")
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
-        if (editor == null || file == null) return false
+        if (editor == null || file == null || getElementToAction(project, editor)?.text?.isBlank() ?: true) return false
 
         this.title = computeTitle(project, file, getCurrentSelectionAsRange(editor))
         return true


### PR DESCRIPTION
Add the right-click actions to the dynamic group and check for the psi-element when updating the presentation of the action in the user interface.
For example, when the psi-element of an action is `PsiWhiteSpace` , an unexpected prompt is generated.

Affected actions: intention Actions and right-click actions.

Maybe I'm not familiar enough with the project, and some actions have not been optimized yet, which can be improved in the future.