### PR TITLE
fix(LLMSettingComponent): 修复新装用户引擎未选择情况下的 `Array contains no element matching the predicate.` 异常

### DIFF
--- a/core/src/main/kotlin/cc/unitmesh/devti/settings/LLMSettingComponent.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/settings/LLMSettingComponent.kt
@@ -75,7 +75,7 @@ class LLMSettingComponent(private val settings: AutoDevSettingsState) {
         applySettings(settings, updateParams = false)
     }
     private val _currentSelectedEngine: AIEngines
-        get() = AIEngines.values().first { it.name.lowercase() == aiEngineParam.value.lowercase() }
+        get() = AIEngines.values().firstOrNull { it.name.lowercase() == aiEngineParam.value.lowercase() } ?: AIEngines.OpenAI
 
     private val currentLLMParams: List<LLMParam>
         get() {


### PR DESCRIPTION
```
Cannot create configurable
.....

Caused by: java.util.NoSuchElementException: Array contains no element matching the predicate.
	at cc.unitmesh.devti.settings.LLMSettingComponent.get_currentSelectedEngine(LLMSettingComponent.kt:247)
	at cc.unitmesh.devti.settings.LLMSettingComponent.getCurrentLLMParams(LLMSettingComponent.kt:82)
	at cc.unitmesh.devti.settings.LLMSettingComponent.applySettings(LLMSettingComponent.kt:153)
	at cc.unitmesh.devti.settings.LLMSettingComponent.applySettings$default(LLMSettingComponent.kt:123)
	at cc.unitmesh.devti.settings.LLMSettingComponent.<init>(LLMSettingComponent.kt:241)
	at cc.unitmesh.devti.settings.AutoDevSettingsConfigurable.<init>(AutoDevSettingsConfigurable.kt:10)
	at com.intellij.serviceContainer.ComponentManagerImpl.findConstructorAndInstantiateClass(ComponentManagerImpl.kt:909)
	at com.intellij.serviceContainer.ComponentManagerImpl.doInstantiateClass(ComponentManagerImpl.kt:918)
	... 104 more
```
