### PR TITLE
fix(CustomSSEProcessor): 支持自定义大模型 customFields 使用复杂类型字段

### DIFF
--- a/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/CustomSSEProcessor.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/CustomSSEProcessor.kt
@@ -188,7 +188,7 @@ fun JsonObject.updateCustomBody(customRequest: String): JsonObject {
             val customRequestJson = Json.parseToJsonElement(customRequest).jsonObject
             customRequestJson["customFields"]?.let { customFields ->
                 customFields.jsonObject.forEach { (key, value) ->
-                    put(key, value.jsonPrimitive)
+                    put(key, value)
                 }
             }
 


### PR DESCRIPTION
修正了在处理自定义字段时将所有值强制转换为 `jsonPrimitive` 的问题，改为直接使用字段值。这解决了某些复杂数据结构无法正确解析的问题。

这样允许类似如下的配置：
```json
{ "customFields": { "model":"qwen-plus", "stream": true, "stream_options": {"include_usage": true} }}
```