### PR TITLE
refactor(llm): convert LlmProvider to non-singleton

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -402,6 +402,11 @@ project(":core") {
 
         implementation("io.reactivex.rxjava3:rxjava:3.1.10")
 
+        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+        testImplementation(kotlin("test"))
+        testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0") {
+            excludeKotlinDeps()
+        }
         implementation("com.squareup.okhttp3:okhttp:4.12.0") {
             excludeKotlinDeps()
         }
@@ -681,6 +686,10 @@ project(":exts:devins-lang") {
             dependsOn(generateLexer, generateParser)
         }
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 fun File.isPluginJar(): Boolean {

--- a/core/src/main/kotlin/cc/unitmesh/devti/custom/document/CustomLivingDocTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/custom/document/CustomLivingDocTask.kt
@@ -26,7 +26,7 @@ class CustomLivingDocTask(
         logger.info("Prompt: $prompt")
 
         val stream =
-            LlmFactory().create(project).stream(prompt, "", false)
+            LlmFactory.create(project).stream(prompt, "", false)
 
         var result = ""
 

--- a/core/src/main/kotlin/cc/unitmesh/devti/custom/tasks/FileGenerateTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/custom/tasks/FileGenerateTask.kt
@@ -34,7 +34,7 @@ class FileGenerateTask(
         val systemPrompt = messages.filter { it.role == LlmMsg.ChatRole.System }.joinToString("\n") { it.content }
 
         val stream =
-            LlmFactory().create(project).stream(requestPrompt, systemPrompt, false)
+            LlmFactory.create(project).stream(requestPrompt, systemPrompt, false)
 
         var result = ""
         runBlocking {

--- a/core/src/main/kotlin/cc/unitmesh/devti/diff/DiffStreamHandler.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/diff/DiffStreamHandler.kt
@@ -123,7 +123,7 @@ class DiffStreamHandler(
         val lines = originContent.lines()
 
         isRunning = true
-        val flow: Flow<String> = LlmFactory.instance.create(project).stream(prompt, "", false)
+        val flow: Flow<String> = LlmFactory.create(project).stream(prompt, "", false)
         var lastLineNo = 0
         AutoDevCoroutineScope.scope(project).launch {
             val suggestion = StringBuilder()

--- a/core/src/main/kotlin/cc/unitmesh/devti/gui/chat/ChatCodingService.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/gui/chat/ChatCodingService.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 class ChatCodingService(var actionType: ChatActionType, val project: Project) {
-    private val llmProvider = LlmFactory().create(project)
+    private val llmProvider = LlmFactory.create(project)
     private val counitProcessor = project.service<CustomAgentChatProcessor>()
     private var currentJob: Job? = null
 

--- a/core/src/main/kotlin/cc/unitmesh/devti/inline/AutoDevInlineChatPanel.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/inline/AutoDevInlineChatPanel.kt
@@ -40,7 +40,7 @@ class AutoDevInlineChatPanel(val editor: Editor) : JPanel(GridBagLayout()), Edit
         val project = editor.project!!
 
         val prompt = AutoDevInlineChatService.getInstance().prompting(project, input, editor)
-        val flow: Flow<String>? = LlmFactory.instance.create(project).stream(prompt, "", false)
+        val flow: Flow<String>? = LlmFactory.create(project).stream(prompt, "", false)
 
         val panelView = SketchToolWindow(project, editor)
         panelView.minimumSize = Dimension(800, 40)

--- a/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/BaseCompletionTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/BaseCompletionTask.kt
@@ -41,7 +41,7 @@ abstract class BaseCompletionTask(private val request: CodeCompletionRequest) :
         val prompt = promptText()
 
         val keepHistory = keepHistory() && prompt.length < AutoDevSettingsState.maxTokenLength
-        val flow: Flow<String> = LlmFactory().create(request.project).stream(prompt, "", keepHistory)
+        val flow: Flow<String> = LlmFactory.create(request.project).stream(prompt, "", keepHistory)
         logger.info("Prompt: $prompt")
 
         DumbAwareAction.create {

--- a/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/CodeCompletionTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/CodeCompletionTask.kt
@@ -27,8 +27,6 @@ import kotlin.jvm.internal.Ref
 class CodeCompletionTask(private val request: CodeCompletionRequest) :
     Task.Backgroundable(request.project, AutoDevBundle.message("intentions.chat.code.complete.name")) {
 
-    private val llmFactory = LlmFactory()
-
     private val writeActionGroupId = "code.complete.intention.write.action"
     private val codeMessage = AutoDevBundle.message("intentions.chat.code.complete.name")
 
@@ -39,7 +37,7 @@ class CodeCompletionTask(private val request: CodeCompletionRequest) :
     override fun run(indicator: ProgressIndicator) {
         val prompt = promptText()
 
-        val flow: Flow<String> = llmFactory.create(request.project).stream(prompt, "", false)
+        val flow: Flow<String> = LlmFactory.create(request.project).stream(prompt, "", false)
         logger.info("Prompt: $prompt")
 
         val editor = request.editor
@@ -92,7 +90,7 @@ class CodeCompletionTask(private val request: CodeCompletionRequest) :
         logger.warn("Prompt: $prompt")
         AutoDevCoroutineScope.scope(project).launch {
             try {
-                val flow: Flow<String> = llmFactory.createForInlayCodeComplete(project).stream(prompt, "", false)
+                val flow: Flow<String> = LlmFactory.createForInlayCodeComplete(project).stream(prompt, "", false)
                 val suggestion = StringBuilder()
                 flow.collect {
                     AutoDevStatusService.notifyApplication(AutoDevStatus.InProgress)

--- a/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/LivingDocumentationTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/LivingDocumentationTask.kt
@@ -35,7 +35,7 @@ class LivingDocumentationTask(
 
         logger.info("Prompt: $prompt")
 
-        val stream = LlmFactory().create(project).stream(prompt, "", false)
+        val stream = LlmFactory.create(project).stream(prompt, "", false)
 
         var result = ""
 

--- a/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/TestCodeGenTask.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/intentions/action/task/TestCodeGenTask.kt
@@ -122,7 +122,7 @@ class TestCodeGenTask(val request: TestCodeGenRequest, displayMessage: String) :
         indicator.text = AutoDevBundle.message("intentions.request.background.process.title")
 
         val flow: Flow<String> = try {
-            LlmFactory().create(request.project).stream(prompter, "", false)
+            LlmFactory.create(request.project).stream(prompter, "", false)
         } catch (e: Exception) {
             AutoDevStatusService.notifyApplication(AutoDevStatus.Error)
             logger.error("Failed to create LLM for: $lang", e)

--- a/core/src/main/kotlin/cc/unitmesh/devti/llm2/ChatSession.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llm2/ChatSession.kt
@@ -1,0 +1,88 @@
+package cc.unitmesh.devti.llm2
+
+import cc.unitmesh.devti.llm2.MessageStatus.*
+import cc.unitmesh.devti.llms.custom.Message
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * 后台返回消息状态：[BEGIN] 首次返回 [CONTENT] 中间内容 [END] 内容结束
+ */
+enum class MessageStatus {
+    BEGIN, CONTENT, END
+}
+
+/**
+ * 聊天会话，每个会话包含此次会话的所有消息和名称。
+ */
+data class ChatSession<T>(
+    val conversionName: String,
+    val chatHistory: List<SessionMessageItem<T>>,
+    /**
+     * 当前会话状态，为 [MessageStatus.END] 时才允许发下一个对话
+     */
+    var status: MessageStatus = END,
+) {
+    companion object {
+        /**
+         * 为方便使用，暂时以 invoke 工厂提供默认的 ChatSession 实现
+         */
+        operator fun invoke(conversionName: String, messages: List<Message> = listOf()): ChatSession<Message> =
+            ChatSession<Message>(conversionName, messages.map { SessionMessageItem(it, END) })
+    }
+}
+
+fun <T> ChatSession<T>.canSendNextMessage() = this.status == END
+
+fun <T> ChatSession<T>.appendMessage(newMessage: T, status: MessageStatus = CONTENT): ChatSession<T> =
+    this.copy(chatHistory = this.chatHistory.toMutableList().apply {
+        add(SessionMessageItem(newMessage, status))
+    })
+
+/**
+ * http 请求的 body 数据
+ */
+val ChatSession<Message>.httpContent: String
+    get() {
+        return chatHistory.filter {
+            // exception 不需要发送给 llm server
+            // TODO 对异常消息的处理需有更合理的设计
+            it.chatMessage.role != "Error"
+        }.joinToString(prefix = """{"messages":[""", postfix = "]}", separator = ",") { item ->
+            Json.encodeToString(item.chatMessage)
+        }
+    }
+
+/**
+ * 聊天消息项
+ * 后续可扩展为多模态消息，T 可为做任意内容
+ *
+ * @property chatMessage 聊天消息
+ * @property status 消息状态，标记此消息的状态是刚开始、中间还是消息已经结束。
+ */
+open class SessionMessageItem<T>(
+    val chatMessage: T,
+    val status: MessageStatus = CONTENT,
+) {
+    companion object {
+
+        /**
+         * 为方便使用，暂时以 invoke 工厂提供默认的文本实现
+         */
+        operator fun invoke(
+            chatMessage: Message,
+            status: MessageStatus = CONTENT,
+        ): SessionMessageItem<Message> =
+            DefaultSessionMessageItem(chatMessage, status)
+
+        val Null = SessionMessageItem(Message("", ""), END)
+    }
+}
+
+/**
+ * 默认的聊天消息项
+ */
+private class DefaultSessionMessageItem(
+    chatMessage: Message,
+    status: MessageStatus = CONTENT,
+) : SessionMessageItem<Message>(chatMessage, status)

--- a/core/src/main/kotlin/cc/unitmesh/devti/llm2/LLMProvider2.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llm2/LLMProvider2.kt
@@ -1,0 +1,281 @@
+package cc.unitmesh.devti.llm2
+
+import cc.unitmesh.devti.llms.custom.CustomRequest
+import cc.unitmesh.devti.llms.custom.Message
+import cc.unitmesh.devti.llms.custom.appendCustomHeaders
+import cc.unitmesh.devti.llms.custom.updateCustomFormat
+import cc.unitmesh.devti.settings.AutoDevSettingsState
+import cc.unitmesh.devti.util.AutoDevAppScope
+import cc.unitmesh.devti.util.AutoDevCoroutineScope
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.nfeld.jsonpathkt.JsonPath
+import com.nfeld.jsonpathkt.extension.read
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import okhttp3.sse.EventSources
+import java.time.Duration
+
+/**
+ * default session postfix
+ * will be incremented for each new session
+ */
+private var sessionId = 0;
+
+/**
+ * LLMProvider provide only session-free interfaces
+ *
+ * It's LLMProvider's responsibility to maintain the network connection
+ * But the chat session is maintained by the client
+ *
+ * [LLMProvider2] provides a factory companion object to create different providers
+ *
+ * for now, we only support text completion, see [DefaultLLMTextProvider].
+ * you can implement your own provider by extending [LLMProvider2]
+ * and override [textComplete] method
+ *
+ * ```kotlin
+ * val provider = LLMProvider2()
+ * val session = ChatSession("sessionName")
+ * // if you don't need to maintain the history, you can ignore the session
+ * // stream is default to true
+ * provider.request("text", session = session, stream = true).catch {
+ *   // handle errors
+ * }.collect {
+ *    // incoming new message without the original history messages
+ * }
+ * ```
+ *
+ * @property project if not null means this is a project level provider, will be disposed when project closed
+ */
+abstract class LLMProvider2 protected constructor(
+    protected val project: Project?,
+    protected val logger: Logger = logger<LLMProvider2>(),
+    protected val httpClient: OkHttpClient = OkHttpClient(),
+) {
+    /**
+     * The job that is sending the request
+     */
+    protected var _sendingJob: Job? = null
+
+    /**
+     * 为会话创建一个 CoroutineScope
+     *
+     * TODO: 支持同一 session 同时发送多个请求
+     */
+    protected fun sessionScope(session: ChatSession<Message>): CoroutineScope {
+        return if (project != null) {
+            AutoDevCoroutineScope.scope(project)
+        } else {
+            AutoDevAppScope.scope()
+        }
+    }
+
+
+    /**
+     * Send a text to the LLM
+     * response will be emitted to [response]
+     *
+     * return a job that can be used to cancel the request
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    suspend fun request(
+        text: Message,
+        stream: Boolean = true,
+        session: ChatSession<Message> = ChatSession("ignoreHistorySession"),
+    ): Flow<SessionMessageItem<Message>> {
+        cancelCurrentRequest(session)
+        return textComplete(session.appendMessage(text), stream)
+    }
+
+    /**
+     * 根据 session 中的 chatHistory 发送请求，在数据触发过程中通过 [response] 发送接收的消息，并在最终完成后返回完整的 [SessionMessageItem]
+     */
+    protected abstract fun textComplete(
+        session: ChatSession<Message>,
+        stream: Boolean = true,
+    ): Flow<SessionMessageItem<Message>>
+
+    /**
+     * 同步取消当前请求，并将等待请求完成
+     */
+    suspend fun cancelCurrentRequest(session: ChatSession<Message>) {
+        _sendingJob?.cancelAndJoin()
+    }
+
+    /**
+     * 取消当前请求，本 api 不会等待请求完成
+     */
+    fun cancelCurrentRequestSync() {
+        _sendingJob?.cancel()
+    }
+
+    companion object {
+
+        /**
+         * 返回在配置中设置的 provider
+         */
+        operator fun invoke(autoDevSettingsState: AutoDevSettingsState = AutoDevSettingsState.getInstance()): LLMProvider2 =
+            LLMProvider2(
+                requestUrl = autoDevSettingsState.customEngineServer,
+                authorizationKey = autoDevSettingsState.openAiKey,
+                responseResolver = autoDevSettingsState.customEngineResponseFormat,
+                requestCostomize = autoDevSettingsState.customEngineRequestFormat,
+            )
+
+        /**
+         * 默认返回兼容 OpenAI 的 provider
+         */
+        operator fun invoke(
+            requestUrl: String,
+            authorizationKey: String,
+            responseResolver: String = "\$.choices[0].delta.content",
+            requestCostomize: String = "",
+        ): LLMProvider2 = DefaultLLMTextProvider(
+            requestUrl = requestUrl,
+            authorizationKey = authorizationKey,
+            responseResolver = responseResolver,
+            requestCustomize = requestCostomize,
+        )
+
+        /**
+         * Ollama Provider，不需提供 authorizationKey
+         */
+        fun Ollama(
+            modelName: String,
+            requestUrl: String = "http://localhost:11434/v1/chat/completions",
+            responseResolver: String = "\$.choices[0].delta.content",
+        ): LLMProvider2 = LLMProvider2(
+            requestUrl = requestUrl,
+            authorizationKey = "",
+            responseResolver = responseResolver,
+            requestCostomize = """{ "customFields": {"model": "$modelName", "temperature": 0.7 } }""",
+        )
+    }
+}
+
+private class DefaultLLMTextProvider(
+    private val requestUrl: String,
+    private val authorizationKey: String,
+    private val responseResolver: String = "\$.choices[0].delta.content",
+    private val requestCustomize: String = "{}",
+    project: Project? = null,
+) : LLMProvider2(project) {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun textComplete(session: ChatSession<Message>, stream: Boolean): Flow<SessionMessageItem<Message>> {
+        val client = httpClient.newBuilder().readTimeout(Duration.ofSeconds(30)).build()
+        val requestBuilder = Request.Builder().apply {
+            if (authorizationKey.isNotEmpty()) {
+                addHeader("Authorization", "Bearer $authorizationKey")
+            }
+            appendCustomHeaders(requestCustomize)
+        }
+        val customRequest = CustomRequest(session.chatHistory.map {
+            val cm = it.chatMessage
+            Message(cm.role, cm.content ?: "")
+        })
+        val requestBodyText = customRequest.updateCustomFormat(requestCustomize, stream)
+        val requestBody = requestBodyText.toRequestBody("application/json".toMediaTypeOrNull())
+        println("requestUrl: $requestUrl")
+        val request: Request = requestBuilder.url(requestUrl).post(requestBody).build()
+
+        return callbackFlow {
+            _sendingJob = sessionScope(session).launch {
+                if (stream) {
+                    sseStream(
+                        client,
+                        request,
+                        onFailure = {
+                            close(it)
+                        },
+                        onClosed = {
+                            close()
+                        },
+                        onEvent = {
+                            trySend(it)
+                        }
+                    )
+                } else {
+                    kotlin.runCatching {
+                        val result = directResult(client, request)
+                        trySend(result)
+                        close()
+                    }.onFailure {
+                        close(it)
+                    }
+                }
+            }
+            awaitClose()
+        }
+    }
+
+    private suspend fun sseStream(
+        client: OkHttpClient,
+        request: Request,
+        onEvent: (SessionMessageItem<Message>) -> Unit,
+        onFailure: (Throwable) -> Unit,
+        onClosed: () -> Unit,
+        onOpen: () -> Unit = {},
+    ) {
+        val factory = EventSources.createFactory(client)
+        var result = ""
+        factory.newEventSource(request, object : EventSourceListener() {
+            override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                super.onEvent(eventSource, id, type, data)
+                if (data == "[DONE]") {
+                    return
+                }
+                val chunk: String = JsonPath.parse(data)?.read(responseResolver) ?: run {
+                    // in some case, the response maybe not equal to our response format, so we need to ignore it
+                    // {"id":"cmpl-ac26a17e","object":"chat.completion.chunk","created":1858403,"model":"yi-34b-chat","choices":[{"delta":{"role":"assistant"},"index":0}],"content":"","lastOne":false}
+                    logger.warn(IllegalStateException("cannot parse with responseResolver: ${responseResolver}, ori data: $data"))
+                    ""
+                }
+                result += chunk
+                onEvent(SessionMessageItem(Message("system", result)))
+            }
+
+            override fun onClosed(eventSource: EventSource) {
+                if (result.isEmpty()) {
+                    onFailure(IllegalStateException("response is empty"))
+                }
+                onClosed()
+            }
+
+            override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+                onFailure(t ?: RuntimeException("${response?.code} ${response?.message} ${response?.body?.string()}"))
+            }
+
+            override fun onOpen(eventSource: EventSource, response: Response) {
+                onOpen()
+            }
+        })
+    }
+
+    private fun directResult(client: OkHttpClient, request: Request): SessionMessageItem<Message> {
+        client.newCall(request).execute().use {
+            val body = it.body
+            if (body == null) {
+                logger.error("response body is null")
+                return SessionMessageItem(Message("system", "response body is null"))
+            } else {
+                val content = body.string()
+                val result: String = JsonPath.parse(content)?.read(responseResolver) ?: run {
+                    throw IllegalStateException("cannot parse with responseResolver: ${responseResolver}, ori data: $content")
+                }
+                return SessionMessageItem(Message("system", result))
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/cc/unitmesh/devti/llms/LlmFactory.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llms/LlmFactory.kt
@@ -8,22 +8,18 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 
-@Service
-class LlmFactory {
+object LlmFactory {
     fun create(project: Project): LLMProvider {
-        return project.getService(CustomLLMProvider::class.java)
+        return CustomLLMProvider(project)
     }
 
     fun createForInlayCodeComplete(project: Project): LLMProvider {
         if(project.service<AutoDevCoderSettingService>().state.useCustomAIEngineWhenInlayCodeComplete) {
             logger<LlmFactory>().info("useCustomAIEngineWhenInlayCodeComplete: ${project.service<AutoDevCoderSettingService>().state.useCustomAIEngineWhenInlayCodeComplete}")
-            return project.getService(InlayCustomLLMProvider::class.java)
+            return InlayCustomLLMProvider(project)
         }
 
         return create(project);
     }
 
-    companion object {
-        val instance: LlmFactory = LlmFactory()
-    }
 }

--- a/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/CustomLLMProvider.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/CustomLLMProvider.kt
@@ -16,7 +16,9 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import java.time.Duration
 
-@Service(Service.Level.PROJECT)
+/**
+ * LLMProvider 不应该是单例 Service，它有多个并发场景的可能性
+ */
 class CustomLLMProvider(val project: Project) : LLMProvider, CustomSSEProcessor(project) {
     private val autoDevSettingsState = getSetting()
     private fun getSetting() = AutoDevSettingsState.getInstance()

--- a/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/InlayCustomLLMProvider.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/llms/custom/InlayCustomLLMProvider.kt
@@ -19,7 +19,6 @@ import okhttp3.RequestBody
 import java.time.Duration
 
 //TODO: refactor, this provider copy from CustomLLMProvider
-@Service(Service.Level.PROJECT)
 class InlayCustomLLMProvider(val project: Project) : LLMProvider, CustomSSEProcessor(project) {
     private val autoDevSettingsState = project.service<AutoDevCoderSettingService>().state
     private val url get() = autoDevSettingsState.customEngineServerParam

--- a/core/src/main/kotlin/cc/unitmesh/devti/practise/RenameLookupManagerListener.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/practise/RenameLookupManagerListener.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.*
 
 // TODO: spike why TypeScript not trigger this listener when rename a class, function, but Java does
 class RenameLookupManagerListener(val project: Project) : LookupManagerListener {
-    private val llm = LlmFactory.instance.create(project)
+    private val llm = LlmFactory.create(project)
     private val logger = logger<RenameLookupManagerListener>()
 
     override fun activeLookupChanged(oldLookup: Lookup?, newLookup: Lookup?) {

--- a/core/src/main/kotlin/cc/unitmesh/devti/runconfig/AutoDevRunProfileState.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/runconfig/AutoDevRunProfileState.kt
@@ -52,7 +52,7 @@ class AutoDevRunProfileState(
             logger.error("current Language don't implementation DevFlow")
             return null
         }
-        val openAIRunner = LlmFactory().create(project)
+        val openAIRunner = LlmFactory.create(project)
 
         sendToChatPanel(project) { contentPanel, _ ->
             flowProvider.initContext(kanban, openAIRunner, contentPanel, project)

--- a/core/src/main/kotlin/cc/unitmesh/devti/settings/LLMSettingComponent.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/settings/LLMSettingComponent.kt
@@ -99,10 +99,7 @@ class LLMSettingComponent(private val settings: AutoDevSettingsState) {
             .addLLMParam(maxTokenLengthParam)
             .addLLMParam(delaySecondsParam)
             .addComponent(panel {
-                if (project != null) {
-                    testLLMConnection(project)
-                }
-
+                testLLMConnection()
                 row {
                     text(AutoDevBundle.message("settings.autodev.coder.testConnectionButton.tips")).apply {
                         this.component.foreground = JBColor.RED

--- a/core/src/main/kotlin/cc/unitmesh/devti/settings/TestConnection.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/settings/TestConnection.kt
@@ -1,31 +1,37 @@
 package cc.unitmesh.devti.settings
 
+import cc.unitmesh.cf.core.llms.LlmMsg
 import cc.unitmesh.devti.fullWidthCell
-import cc.unitmesh.devti.llms.LlmFactory
-import cc.unitmesh.devti.util.AutoDevCoroutineScope
-import com.intellij.openapi.project.Project
+import cc.unitmesh.devti.llm2.LLMProvider2
+import cc.unitmesh.devti.llms.custom.Message
 import com.intellij.ui.dsl.builder.Panel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.swing.JLabel
 
-fun Panel.testLLMConnection(project: Project?) {
+fun Panel.testLLMConnection() {
     row {
         // test result
         val result = JLabel("")
         button("Test LLM Connection") {
-            if (project == null) return@button
+            val scope = CoroutineScope(CoroutineName("testConnection"))
             result.text = ""
+            result.isEnabled = false
 
             // test custom engine
-            AutoDevCoroutineScope.scope(project).launch {
+            scope.launch {
                 try {
-                    val flowString: Flow<String> = LlmFactory.instance.create(project).stream("hi", "", false)
-                    flowString.collect {
-                        result.text += it
+                    val llmProvider2 = LLMProvider2()
+                    val response = llmProvider2.request(Message(LlmMsg.ChatRole.User.toString(),"hi!"))
+                    response.collectLatest {
+                        result.text = it.chatMessage.content
                     }
                 } catch (e: Exception) {
                     result.text = e.message ?: "Unknown error"
+                } finally {
+                    result.isEnabled = true
                 }
             }
         }

--- a/core/src/main/kotlin/cc/unitmesh/devti/settings/coder/AutoDevCoderConfigurable.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/settings/coder/AutoDevCoderConfigurable.kt
@@ -164,12 +164,10 @@ class AutoDevCoderConfigurable(private val project: Project) : BoundConfigurable
                 )
         }
 
-        if (project != null) {
-            testLLMConnection(project)
-            row {
-                text(AutoDevBundle.message("settings.autodev.coder.testConnectionButton.tips")).apply {
-                    this.component.foreground = JBColor.RED
-                }
+        testLLMConnection()
+        row {
+            text(AutoDevBundle.message("settings.autodev.coder.testConnectionButton.tips")).apply {
+                this.component.foreground = JBColor.RED
             }
         }
 

--- a/core/src/main/kotlin/cc/unitmesh/devti/util/AutoDevCoroutineScope.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/util/AutoDevCoroutineScope.kt
@@ -1,28 +1,56 @@
 package cc.unitmesh.devti.util
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.AppExecutorUtil
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.*
 
-public val workerThread = AppExecutorUtil.getAppExecutorService().asCoroutineDispatcher()
+private val workerThread = AppExecutorUtil.getAppExecutorService().asCoroutineDispatcher()
 
-@Service(Service.Level.PROJECT)
-class AutoDevCoroutineScope {
+@Service(Service.Level.APP)
+class AutoDevAppScope: Disposable {
     private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        Logger.getInstance(AutoDevCoroutineScope::class.java).error(throwable)
+        logger<AutoDevAppScope>().error(throwable)
+    }
+    val coroutineScope = CoroutineScope(SupervisorJob() + coroutineExceptionHandler)
+    val workerScope = CoroutineScope(SupervisorJob() + workerThread)
+
+    override fun dispose() {
+        coroutineScope.cancel()
+        workerScope.cancel()
+    }
+
+    companion object {
+        fun scope(): CoroutineScope = service<AutoDevAppScope>().coroutineScope
+        fun workerScope(): CoroutineScope = service<AutoDevAppScope>().workerScope
+    }
+}
+@Service(Service.Level.PROJECT)
+class AutoDevCoroutineScope : Disposable {
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        logger<AutoDevCoroutineScope>().error(throwable)
     }
 
     val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + coroutineExceptionHandler)
+    val workerScope: CoroutineScope = CoroutineScope(SupervisorJob() + workerThread)
+
+    override fun dispose() {
+        coroutineScope.cancel()
+        workerScope.cancel()
+    }
 
     companion object {
         fun scope(project: Project): CoroutineScope = project.service<AutoDevCoroutineScope>().coroutineScope
 
+
+        @Deprecated(
+            message = "using this may cause memory leak after project close",
+            replaceWith = ReplaceWith("AutoDevCoroutineScope.workScope(project)", imports = ["cc.unitmesh.devti.util.AutoDevCoroutineScope"])
+        )
         fun workerThread(): CoroutineScope = CoroutineScope(SupervisorJob() + workerThread)
+        fun workerScope(project: Project): CoroutineScope = project.service<AutoDevCoroutineScope>().coroutineScope
     }
 }

--- a/core/src/test/kotlin/cc/unitmesh/devti/llm2/LLMProvider2Test.kt
+++ b/core/src/test/kotlin/cc/unitmesh/devti/llm2/LLMProvider2Test.kt
@@ -1,0 +1,161 @@
+package cc.unitmesh.devti.llm2
+
+import cc.unitmesh.devti.llms.custom.Message
+import cc.unitmesh.devti.settings.AutoDevSettingsState
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.collectIndexed
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+
+class LLMProvider2Test {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var llmProvider2: LLMProvider2
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val settings = AutoDevSettingsState().apply {
+            customEngineServer = mockWebServer.url("/").toString()
+            customModel = "test-model"
+            customEngineResponseFormat = "\$.choices[0].delta.content"
+            customEngineRequestFormat = "{}"
+        }
+
+        llmProvider2 = LLMProvider2(settings)
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun shouldWorkWithJson() = runBlocking {
+        val mockResponse = MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-Type", "application/json")
+            .setBody(
+                """{"choices":[{"delta":{"role":"assistant","content":"Hello"}}]}"""
+            )
+        mockWebServer.enqueue(mockResponse)
+
+        val response = llmProvider2.request(Message("User", "hi!"), false)
+        response.collectLatest {
+            println(it.chatMessage.content)
+            assertEquals("Hello", it.chatMessage.content)
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun shouldFailIfResponseOnlyWithIllegalJson() {
+        runBlocking {
+            val mockResponse = MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody(
+                    """{"choices":[{"delta":{"role":"assistant","__content":"Hello"}}]}
+                    """.trimMargin()
+                )
+            mockWebServer.enqueue(mockResponse)
+
+            val response = llmProvider2.request(Message("User", "hi!"), false)
+            response.collectLatest { }
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun shouldFailIfResponseOnlyWithIllegalJsonStream() {
+        runBlocking {
+            val mockResponse = MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """data: {"choices":[{"delta":{"role":"assistant","__content":"Hello"}}]}
+                        |
+                        |
+                    """.trimMargin()
+                )
+            mockWebServer.enqueue(mockResponse)
+
+            val response = llmProvider2.request(Message("User", "hi!"), true)
+            response.collectLatest { }
+        }
+    }
+
+    @Test
+    fun shouldIgnoreIllegalResponse() = runBlocking {
+        val mockResponse = MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-Type", "text/event-stream")
+            .setBody(
+                """data: {"choices":[{"delta":{"role":"assistant","content":"Hello"}}]}
+                    |
+                    |data: {"id":"cmpl-ac26a17e","object":"chat.completion.chunk","created":1858403,"model":"yi-34b-chat","choices":[{"delta":{"role":"assistant"},"index":0}],"content":"","lastOne":false}
+                    |
+                    |data: [DONE]
+                    |
+                """.trimMargin()
+            )
+        mockWebServer.enqueue(mockResponse)
+
+        val response = llmProvider2.request(Message("User", "hi!"), true)
+        response.collectLatest {
+            assertEquals("Hello", it.chatMessage.content)
+        }
+    }
+
+    @Test
+    fun shouldEmitChanges() = runTest {
+        val mockResponse = MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-Type", "text/event-stream")
+            .setBody(
+                """data: {"choices":[{"delta":{"role":"assistant","content":"Hello"}}]}
+                    |
+                    |data: {"choices":[{"delta":{"role":"assistant","content":" World"}}]}
+                    |
+                    |data: [DONE]
+                    |
+                """.trimMargin()
+            )
+        mockWebServer.enqueue(mockResponse)
+        llmProvider2.request(Message("User", "hi!"), true).collectIndexed { index, value ->
+            when (index) {
+                0 -> assertEquals("Hello", value.chatMessage.content)
+                1 -> assertEquals("Hello World", value.chatMessage.content)
+            }
+        }
+    }
+
+    @Ignore("This test is for local server")
+    @Test(timeout = 10000)
+    fun ollamaTestStream() = runTest {
+        val result = LLMProvider2.Ollama("codellama:13b").request(Message("User", "hi!"), stream = true)
+        result.collect {
+            println(it.chatMessage.content)
+        }
+    }
+
+    @Ignore("This test is for local server")
+    @Test(timeout = 10000)
+    fun ollamaTestWitoutStream() = runTest {
+        val result = LLMProvider2.Ollama(
+            "codellama:13b",
+            responseResolver = "\$.choices[0].message.content"
+        ).request(Message("User", "hi!"), stream = false)
+        result.collect {
+            println(it.chatMessage.content)
+        }
+    }
+
+}

--- a/exts/devins-lang/src/main/kotlin/cc/unitmesh/devti/language/run/DevInsRunConfigurationProfileState.kt
+++ b/exts/devins-lang/src/main/kotlin/cc/unitmesh/devti/language/run/DevInsRunConfigurationProfileState.kt
@@ -45,7 +45,7 @@ open class DevInsRunConfigurationProfileState(
     private val myProject: Project,
     private val configuration: DevInsConfiguration,
 ) : RunProfileState {
-    private val llm: LLMProvider = LlmFactory.instance.create(myProject)
+    private val llm: LLMProvider = LlmFactory.create(myProject)
 
     override fun execute(executor: Executor?, runner: ProgramRunner<*>): ExecutionResult {
         val processHandler = DevInsProcessHandler(configuration.name)

--- a/exts/ext-database/src/main/kotlin/cc/unitmesh/database/actions/AutoSqlAction.kt
+++ b/exts/ext-database/src/main/kotlin/cc/unitmesh/database/actions/AutoSqlAction.kt
@@ -61,7 +61,7 @@ class AutoSqlAction : ChatBaseIntention() {
         val actions = DbContextActionProvider(dasTables)
 
         sendToChatPanel(project) { contentPanel, _ ->
-            val llmProvider = LlmFactory().create(project)
+            val llmProvider = LlmFactory.create(project)
             val prompter = AutoSqlFlow(genSqlContext, actions, contentPanel, llmProvider)
 
             val task = AutoSqlBackgroundTask(project, prompter, editor, file.language)

--- a/exts/ext-git/src/main/kotlin/cc/unitmesh/git/actions/vcs/CommitMessageSuggestionAction.kt
+++ b/exts/ext-git/src/main/kotlin/cc/unitmesh/git/actions/vcs/CommitMessageSuggestionAction.kt
@@ -90,7 +90,7 @@ class CommitMessageSuggestionAction : ChatBaseAction() {
 
             event.presentation.icon = AutoDevStatus.InProgress.icon
             try {
-                val stream = LlmFactory().create(project).stream(prompt, "", false)
+                val stream = LlmFactory.create(project).stream(prompt, "", false)
                 currentJob = AutoDevCoroutineScope.scope(project).launch {
                     runBlocking {
                         stream

--- a/exts/ext-terminal/src/main/kotlin/cc/unitmesh/terminal/ShellCommandSuggestAction.kt
+++ b/exts/ext-terminal/src/main/kotlin/cc/unitmesh/terminal/ShellCommandSuggestAction.kt
@@ -141,7 +141,7 @@ class ShellCommandSuggestAction : DumbAwareAction() {
             )
             val promptText = templateRender.renderTemplate(template)
 
-            val llm = LlmFactory.instance.create(project)
+            val llm = LlmFactory.create(project)
             val stringFlow: Flow<String> = llm.stream(promptText, "", false)
 
             AutoDevCoroutineScope.scope(project).launch {

--- a/java/src/main/kotlin/cc/unitmesh/idea/actions/AutoCrudAction.kt
+++ b/java/src/main/kotlin/cc/unitmesh/idea/actions/AutoCrudAction.kt
@@ -41,7 +41,7 @@ class AutoCrudAction : ChatBaseIntention() {
         }
 
         sendToChatPanel(project) { contentPanel, _ ->
-            val openAIRunner = LlmFactory().create(project)
+            val openAIRunner = LlmFactory.create(project)
             val selectedText = editor.selectionModel.selectedText ?: throw IllegalStateException("no select text")
             flowProvider.initContext(null, openAIRunner, contentPanel, project)
             ProgressManager.getInstance().run(executeCrud(flowProvider, project, selectedText))

--- a/javascript/src/main/kotlin/cc/unitmesh/ide/javascript/actions/AutoPageAction.kt
+++ b/javascript/src/main/kotlin/cc/unitmesh/ide/javascript/actions/AutoPageAction.kt
@@ -37,7 +37,7 @@ class AutoPageAction : ChatBaseIntention() {
         val reactAutoPage = ReactAutoPage(project, selectedText, editor)
 
         sendToChatPanel(project) { contentPanel, _ ->
-            val llmProvider = LlmFactory().create(project)
+            val llmProvider = LlmFactory.create(project)
             val context = AutoPageContext.build(reactAutoPage,  language, frameworks)
             val prompter = AutoPageFlow(context, contentPanel, llmProvider)
 


### PR DESCRIPTION
- Changed LlmFactory from a class to a singleton object to simplify instantiation.
- Updated all references to use LlmFactory.create() instead of LlmFactory() or LlmFactory.instance.create().
- Removed unnecessary project parameter from testLLMConnection().
- Added LLMProvider2 for improved LLM session management and testing.