### PR TITLE
feat(mcp): 添加 McpParam 注解支持工具参数描述

### DIFF
--- a/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/AutoDevMcpTools.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/AutoDevMcpTools.kt
@@ -76,7 +76,7 @@ class IssueEvaluateTool : AbstractMcpTool<IssueArgs>() {
 }
 
 @Serializable
-data class CreateTestForFileArgs(val fileName: String)
+data class CreateTestForFileArgs(@McpParam(description = "file_name for create test") val fileName: String)
 
 class CreateTestForFileTool : AbstractMcpTool<CreateTestForFileArgs>() {
     override val name: String = "create_test_for_file"

--- a/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/HostMCPService.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/HostMCPService.kt
@@ -170,12 +170,13 @@ class MCPService : RestService() {
 
         val properties = constructor.parameters.mapNotNull { param ->
             param.name?.let { name ->
+                val description = param.annotations.filterIsInstance<McpParam>().firstOrNull()?.description
                 name to when (param.type.classifier) {
-                    String::class -> PropertySchema("string")
-                    Int::class, Long::class, Double::class, Float::class -> PropertySchema("number")
-                    Boolean::class -> PropertySchema("boolean")
-                    List::class -> PropertySchema("array")
-                    else -> PropertySchema("object")
+                    String::class -> PropertySchema("string", description)
+                    Int::class, Long::class, Double::class, Float::class -> PropertySchema("number", description)
+                    Boolean::class -> PropertySchema("boolean", description)
+                    List::class -> PropertySchema("array", description)
+                    else -> PropertySchema("object", description)
                 }
             }
         }.toMap()

--- a/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/McpParam.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/McpParam.kt
@@ -1,0 +1,9 @@
+package cc.unitmesh.devti.mcp.host
+
+/**
+ * Annotation to provide description for MCP tool parameters
+ * @param description The description of the parameter that will be exposed to MCP clients
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class McpParam(val description: String)

--- a/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/McpTool.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/mcp/host/McpTool.kt
@@ -50,5 +50,6 @@ data class JsonSchemaObject(
 
 @Serializable
 data class PropertySchema(
-    val type: String
+    val type: String,
+    val description: String? = null
 )


### PR DESCRIPTION
新增 McpParam 注解用于为 MCP 工具参数提供描述信息，并更新 PropertySchema 支持描述字段。这样可以让 MCP 客户端更好地理解工具参数的用途。