### PR TITLE
feat(settings): 刷新后保持用户选择的LLM模型配置

### DIFF
--- a/core/src/main/kotlin/cc/unitmesh/devti/settings/model/LLMModelManager.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/settings/model/LLMModelManager.kt
@@ -449,6 +449,18 @@ class LLMModelManager(
                         fastApplyLLMDropdown
                     )
                     updateLLMTable(tableModel)
+
+                    // Option to restore user settings after refresh
+                    setSelectedModels(
+                        settings,
+                        defaultModelDropdown,
+                        planLLMDropdown,
+                        actLLMDropdown,
+                        completionLLMDropdown,
+                        embeddingLLMDropdown,
+                        fastApplyLLMDropdown
+                    )
+
                     Messages.showInfoMessage(
                         "GitHub Copilot models refreshed successfully!",
                         "Refresh Complete"


### PR DESCRIPTION
在GitHub Copilot模型刷新后添加恢复用户设置功能，确保刷新操作不会重置用户已选择的模型配置。