### PR TITLE
fix(input): 优化Enter键处理避免与代码补全冲突

### DIFF
--- a/core/src/main/kotlin/cc/unitmesh/devti/gui/chat/ui/AutoDevInput.kt
+++ b/core/src/main/kotlin/cc/unitmesh/devti/gui/chat/ui/AutoDevInput.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.openapi.editor.actions.EnterAction
 import com.intellij.openapi.editor.actions.IncrementalFindAction
+import com.intellij.codeInsight.lookup.LookupManagerListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.editor.ex.EditorEx
@@ -53,6 +54,8 @@ class AutoDevInput(
         editorListeners.multicaster.onSubmit(inputSection, AutoDevInputTrigger.Key)
     }
     
+    private val enterShortcutSet = CustomShortcutSet(KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), null))
+
     private val newlineAction = DumbAwareAction.create {
         val editor = editor ?: return@create
         insertNewLine(editor)
@@ -94,10 +97,8 @@ class AutoDevInput(
 
         background = EditorColorsManager.getInstance().globalScheme.defaultBackground
 
-        submitAction.registerCustomShortcutSet(
-            CustomShortcutSet(KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), null)), 
-            this
-        )
+        // 初始注册 Enter 键快捷键
+        registerEnterShortcut()
         
         newlineAction.registerCustomShortcutSet(
             CustomShortcutSet(
@@ -110,6 +111,27 @@ class AutoDevInput(
         listeners.forEach { listener ->
             document.addDocumentListener(listener)
         }
+
+        // 监听补全弹窗状态，动态注册/注销 Enter 键
+        project.messageBus.connect(disposable ?: this).subscribe(LookupManagerListener.TOPIC, object : LookupManagerListener {
+            override fun activeLookupChanged(oldLookup: com.intellij.codeInsight.lookup.Lookup?, newLookup: com.intellij.codeInsight.lookup.Lookup?) {
+                if (newLookup != null) {
+                    // 有补全弹窗时，注销 Enter 键快捷键
+                    unregisterEnterShortcut()
+                } else {
+                    // 没有补全弹窗时，注册 Enter 键快捷键
+                    registerEnterShortcut()
+                }
+            }
+        })
+    }
+
+    private fun registerEnterShortcut() {
+        submitAction.registerCustomShortcutSet(enterShortcutSet, this)
+    }
+
+    private fun unregisterEnterShortcut() {
+        submitAction.unregisterCustomShortcutSet(this)
     }
 
     override fun onEditorAdded(editor: Editor) {


### PR DESCRIPTION
修复AutoDevInput中Enter键快捷键与IDE代码补全弹窗的冲突问题。通过监听LookupManagerListener动态注册/注销Enter键快捷键，确保补全弹窗显示时Enter键用于选择补全项，弹窗关闭时用于提交输入。