### PR TITLE
feat(mpp-idea): implement CodingAgent UI with Jewel theme

### DIFF
--- a/mpp-idea/build.gradle.kts
+++ b/mpp-idea/build.gradle.kts
@@ -17,7 +17,8 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(
             listOf(
-                "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi"
+                "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                "-opt-in=org.jetbrains.jewel.foundation.ExperimentalJewelApi"
             )
         )
     }
@@ -30,14 +31,18 @@ repositories {
         defaultRepositories()
     }
     google()
+    maven("https://packages.jetbrains.team/maven/p/kpm/public/")
 }
 
 dependencies {
     // Kotlinx serialization for JSON
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
 
     testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
 
     intellijPlatform {
         // Target IntelliJ IDEA 2025.2+ for Compose support
@@ -52,7 +57,9 @@ dependencies {
             "intellij.platform.jewel.foundation",
             "intellij.platform.jewel.ui",
             "intellij.platform.jewel.ideLafBridge",
-            "intellij.platform.compose"
+            "intellij.platform.compose",
+            "intellij.platform.jewel.markdown.core",
+            "intellij.platform.jewel.markdown.extension.gfmAlerts"
         )
 
         testFramework(TestFrameworkType.Platform)

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/IdeaAgentRenderer.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/IdeaAgentRenderer.kt
@@ -1,0 +1,171 @@
+package cc.unitmesh.devins.idea.agent
+
+import androidx.compose.runtime.*
+import kotlinx.datetime.Clock
+
+/**
+ * Timeline item types for the agent chat interface.
+ * Simplified version for IntelliJ IDEA integration.
+ */
+sealed class TimelineItem(val timestamp: Long = Clock.System.now().toEpochMilliseconds()) {
+    data class MessageItem(
+        val content: String,
+        val isUser: Boolean,
+        val tokenInfo: TokenInfo? = null,
+        val itemTimestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : TimelineItem(itemTimestamp)
+
+    data class ToolCallItem(
+        val toolName: String,
+        val details: String?,
+        val fullParams: String? = null,
+        val success: Boolean? = null, // null means still executing
+        val summary: String? = null,
+        val output: String? = null,
+        val fullOutput: String? = null,
+        val executionTimeMs: Long? = null,
+        val itemTimestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : TimelineItem(itemTimestamp)
+
+    data class ErrorItem(
+        val error: String,
+        val itemTimestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : TimelineItem(itemTimestamp)
+
+    data class TaskCompleteItem(
+        val success: Boolean,
+        val message: String,
+        val itemTimestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : TimelineItem(itemTimestamp)
+
+    data class TerminalOutputItem(
+        val command: String,
+        val output: String,
+        val exitCode: Int,
+        val executionTimeMs: Long,
+        val itemTimestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : TimelineItem(itemTimestamp)
+}
+
+/**
+ * Token usage information for LLM responses.
+ */
+data class TokenInfo(
+    val inputTokens: Int = 0,
+    val outputTokens: Int = 0,
+    val totalTokens: Int = inputTokens + outputTokens
+)
+
+/**
+ * Current tool call information for displaying in-progress operations.
+ */
+data class ToolCallInfo(
+    val toolName: String,
+    val description: String,
+    val details: String? = null
+)
+
+/**
+ * Renderer for the IDEA CodingAgent interface.
+ * Manages timeline state and provides reactive updates for Compose UI.
+ */
+class IdeaAgentRenderer {
+    private val _timeline = mutableStateListOf<TimelineItem>()
+    val timeline: List<TimelineItem> = _timeline
+
+    var currentStreamingOutput by mutableStateOf("")
+        private set
+
+    var currentToolCall by mutableStateOf<ToolCallInfo?>(null)
+        private set
+
+    var isProcessing by mutableStateOf(false)
+        private set
+
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+
+    fun addUserMessage(content: String) {
+        _timeline.add(TimelineItem.MessageItem(content = content, isUser = true))
+    }
+
+    fun addAssistantMessage(content: String, tokenInfo: TokenInfo? = null) {
+        _timeline.add(TimelineItem.MessageItem(content = content, isUser = false, tokenInfo = tokenInfo))
+    }
+
+    fun startStreaming() {
+        isProcessing = true
+        currentStreamingOutput = ""
+    }
+
+    fun appendStreamingContent(content: String) {
+        currentStreamingOutput += content
+    }
+
+    fun endStreaming() {
+        if (currentStreamingOutput.isNotBlank()) {
+            _timeline.add(TimelineItem.MessageItem(content = currentStreamingOutput.trim(), isUser = false))
+        }
+        currentStreamingOutput = ""
+        isProcessing = false
+    }
+
+    fun startToolCall(toolName: String, description: String, details: String? = null) {
+        currentToolCall = ToolCallInfo(toolName, description, details)
+        _timeline.add(
+            TimelineItem.ToolCallItem(
+                toolName = toolName,
+                details = details,
+                success = null // Indicates in-progress
+            )
+        )
+    }
+
+    fun completeToolCall(success: Boolean, summary: String?, output: String? = null, executionTimeMs: Long? = null) {
+        currentToolCall = null
+        // Update the last tool call item with results
+        val lastIndex = _timeline.indexOfLast { it is TimelineItem.ToolCallItem && it.success == null }
+        if (lastIndex >= 0) {
+            val item = _timeline[lastIndex] as TimelineItem.ToolCallItem
+            _timeline[lastIndex] = item.copy(
+                success = success,
+                summary = summary,
+                output = output,
+                executionTimeMs = executionTimeMs
+            )
+        }
+    }
+
+    fun addError(message: String) {
+        errorMessage = message
+        _timeline.add(TimelineItem.ErrorItem(error = message))
+    }
+
+    fun clearError() {
+        errorMessage = null
+    }
+
+    fun addTaskComplete(success: Boolean, message: String) {
+        _timeline.add(TimelineItem.TaskCompleteItem(success = success, message = message))
+        isProcessing = false
+    }
+
+    fun addTerminalOutput(command: String, output: String, exitCode: Int, executionTimeMs: Long) {
+        _timeline.add(TimelineItem.TerminalOutputItem(command, output, exitCode, executionTimeMs))
+    }
+
+    fun clear() {
+        _timeline.clear()
+        currentStreamingOutput = ""
+        currentToolCall = null
+        errorMessage = null
+        isProcessing = false
+    }
+
+    fun forceStop() {
+        currentStreamingOutput = ""
+        currentToolCall = null
+        isProcessing = false
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/IdeaCodingAgentViewModel.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/IdeaCodingAgentViewModel.kt
@@ -1,0 +1,182 @@
+package cc.unitmesh.devins.idea.agent
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Represents the state of the message input.
+ */
+sealed class MessageInputState {
+    abstract val inputText: String
+
+    data object Disabled : MessageInputState() {
+        override val inputText: String = ""
+    }
+
+    data class Enabled(override val inputText: String) : MessageInputState()
+    data class Sending(override val inputText: String) : MessageInputState()
+    data class SendFailed(override val inputText: String, val error: Throwable) : MessageInputState()
+}
+
+/**
+ * ViewModel for the IDEA CodingAgent interface.
+ *
+ * Manages the agent execution, timeline rendering, and UI state.
+ * This is the IntelliJ IDEA version of CodingAgentViewModel from mpp-ui.
+ */
+class IdeaCodingAgentViewModel(
+    private val project: Project,
+    private val coroutineScope: CoroutineScope,
+    private val maxIterations: Int = 100
+) : Disposable {
+
+    val renderer = IdeaAgentRenderer()
+
+    private val _inputState = MutableStateFlow<MessageInputState>(MessageInputState.Disabled)
+    val inputState: StateFlow<MessageInputState> = _inputState.asStateFlow()
+
+    var isExecuting by mutableStateOf(false)
+        private set
+
+    private var currentExecutionJob: Job? = null
+
+    // Configuration state - TODO: integrate with actual LLM service
+    private var isConfigured = false
+
+    /**
+     * Update the input text.
+     */
+    fun onInputChanged(text: String) {
+        _inputState.value = when {
+            _inputState.value is MessageInputState.Sending -> MessageInputState.Sending(text)
+            text.isEmpty() -> MessageInputState.Disabled
+            else -> MessageInputState.Enabled(text)
+        }
+    }
+
+    /**
+     * Execute a task with the given prompt.
+     */
+    fun executeTask(task: String, onConfigRequired: (() -> Unit)? = null) {
+        if (isExecuting) return
+
+        if (task.isBlank()) return
+
+        // Handle built-in commands
+        if (task.trim().startsWith("/")) {
+            handleBuiltinCommand(task.trim())
+            return
+        }
+
+        isExecuting = true
+        renderer.addUserMessage(task)
+
+        currentExecutionJob = coroutineScope.launch {
+            try {
+                // TODO: Integrate with mpp-core CodingAgent
+                // For now, simulate agent execution
+                simulateAgentExecution(task)
+            } catch (e: CancellationException) {
+                renderer.forceStop()
+                renderer.addError("Task cancelled by user")
+            } catch (e: Exception) {
+                renderer.addError(e.message ?: "Unknown error")
+            } finally {
+                isExecuting = false
+                currentExecutionJob = null
+            }
+        }
+    }
+
+    /**
+     * Cancel the current task execution.
+     */
+    fun cancelTask() {
+        currentExecutionJob?.cancel()
+        currentExecutionJob = null
+        isExecuting = false
+        renderer.forceStop()
+    }
+
+    /**
+     * Handle built-in commands like /clear, /help.
+     */
+    private fun handleBuiltinCommand(command: String) {
+        when {
+            command == "/clear" -> {
+                renderer.clear()
+            }
+            command == "/help" -> {
+                renderer.addUserMessage(command)
+                renderer.addAssistantMessage("""
+                    |**Available Commands:**
+                    |
+                    |- `/clear` - Clear the chat history
+                    |- `/help` - Show this help message
+                    |
+                    |**Tips:**
+                    |- Describe your coding task in natural language
+                    |- The agent will analyze, plan, and execute the task
+                """.trimMargin())
+            }
+            else -> {
+                renderer.addUserMessage(command)
+                renderer.addError("Unknown command: $command")
+            }
+        }
+    }
+
+    /**
+     * Simulate agent execution for testing.
+     * TODO: Replace with actual mpp-core CodingAgent integration.
+     */
+    private suspend fun simulateAgentExecution(task: String) {
+        renderer.startStreaming()
+        
+        // Simulate thinking
+        val thinking = "I'll analyze your request and create a plan..."
+        for (char in thinking) {
+            renderer.appendStreamingContent(char.toString())
+            delay(20)
+        }
+        renderer.endStreaming()
+
+        // Simulate tool call
+        renderer.startToolCall("ReadFile", "Reading project files", "src/main/kotlin/...")
+        delay(500)
+        renderer.completeToolCall(true, "Read 3 files", "File contents...", 450)
+
+        // Simulate response
+        renderer.startStreaming()
+        val response = "\n\nBased on my analysis, I've completed the following:\n\n1. Analyzed the codebase\n2. Identified the relevant files\n3. Made the necessary changes\n\nThe task has been completed successfully."
+        for (char in response) {
+            renderer.appendStreamingContent(char.toString())
+            delay(15)
+        }
+        renderer.endStreaming()
+
+        renderer.addTaskComplete(true, "Task completed in 2 iterations")
+    }
+
+    /**
+     * Create a new conversation.
+     */
+    fun onNewConversation() {
+        cancelTask()
+        renderer.clear()
+        _inputState.value = MessageInputState.Disabled
+    }
+
+    override fun dispose() {
+        currentExecutionJob?.cancel()
+        coroutineScope.cancel()
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/AgentMessageList.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/AgentMessageList.kt
@@ -1,0 +1,165 @@
+package cc.unitmesh.devins.idea.agent.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cc.unitmesh.devins.idea.agent.IdeaAgentRenderer
+import cc.unitmesh.devins.idea.agent.TimelineItem
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+
+/**
+ * Agent message list component for displaying the agent timeline.
+ * Uses Jewel theme for IntelliJ IDEA integration.
+ */
+@Composable
+fun AgentMessageList(
+    renderer: IdeaAgentRenderer,
+    modifier: Modifier = Modifier,
+    onOpenFileViewer: ((String) -> Unit)? = null
+) {
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+
+    // Track if user manually scrolled away from bottom
+    var userScrolledAway by remember { mutableStateOf(false) }
+
+    // Function to scroll to bottom
+    fun scrollToBottomIfNeeded() {
+        if (!userScrolledAway) {
+            coroutineScope.launch {
+                delay(50)
+                val lastIndex = maxOf(0, listState.layoutInfo.totalItemsCount - 1)
+                listState.scrollToItem(lastIndex)
+            }
+        }
+    }
+
+    // Monitor scroll state
+    LaunchedEffect(listState.isScrollInProgress) {
+        if (listState.isScrollInProgress) {
+            val lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            val totalItems = listState.layoutInfo.totalItemsCount
+            userScrolledAway = lastVisibleIndex < totalItems - 2
+        }
+    }
+
+    // Scroll when timeline changes
+    LaunchedEffect(renderer.timeline.size) {
+        if (renderer.timeline.isNotEmpty()) {
+            userScrolledAway = false
+            coroutineScope.launch {
+                delay(50)
+                listState.animateScrollToItem(
+                    index = maxOf(0, listState.layoutInfo.totalItemsCount - 1)
+                )
+            }
+        }
+    }
+
+    // Scroll when streaming content changes
+    LaunchedEffect(renderer.currentStreamingOutput) {
+        if (renderer.currentStreamingOutput.isNotEmpty()) {
+            delay(100)
+            scrollToBottomIfNeeded()
+        }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .background(JewelTheme.globalColors.panelBackground),
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        items(
+            items = renderer.timeline,
+            key = { "${it.timestamp}_${it.hashCode()}" }
+        ) { timelineItem ->
+            RenderTimelineItem(
+                timelineItem = timelineItem,
+                onOpenFileViewer = onOpenFileViewer,
+                onExpand = {
+                    coroutineScope.launch {
+                        delay(50)
+                        val totalItems = listState.layoutInfo.totalItemsCount
+                        if (totalItems > 0) {
+                            listState.animateScrollToItem(totalItems - 1)
+                        }
+                    }
+                }
+            )
+        }
+
+        // Show streaming content
+        if (renderer.currentStreamingOutput.isNotEmpty()) {
+            item(key = "streaming") {
+                StreamingMessageItem(content = renderer.currentStreamingOutput)
+            }
+        }
+
+        // Show current tool call
+        renderer.currentToolCall?.let { toolCall ->
+            item(key = "current_tool_call") {
+                CurrentToolCallItem(toolCall = toolCall)
+            }
+        }
+    }
+}
+
+/**
+ * Render a timeline item based on its type.
+ */
+@Composable
+private fun RenderTimelineItem(
+    timelineItem: TimelineItem,
+    onOpenFileViewer: ((String) -> Unit)?,
+    onExpand: () -> Unit = {}
+) {
+    when (timelineItem) {
+        is TimelineItem.MessageItem -> {
+            MessageItem(
+                content = timelineItem.content,
+                isUser = timelineItem.isUser,
+                tokenInfo = timelineItem.tokenInfo
+            )
+        }
+        is TimelineItem.ToolCallItem -> {
+            ToolCallItem(
+                toolName = timelineItem.toolName,
+                details = timelineItem.details,
+                success = timelineItem.success,
+                summary = timelineItem.summary,
+                output = timelineItem.output,
+                executionTimeMs = timelineItem.executionTimeMs,
+                onExpand = onExpand
+            )
+        }
+        is TimelineItem.ErrorItem -> {
+            ErrorItem(error = timelineItem.error)
+        }
+        is TimelineItem.TaskCompleteItem -> {
+            TaskCompletedItem(
+                success = timelineItem.success,
+                message = timelineItem.message
+            )
+        }
+        is TimelineItem.TerminalOutputItem -> {
+            TerminalOutputItem(
+                command = timelineItem.command,
+                output = timelineItem.output,
+                exitCode = timelineItem.exitCode,
+                executionTimeMs = timelineItem.executionTimeMs,
+                onExpand = onExpand
+            )
+        }
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/CodingAgentPanel.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/CodingAgentPanel.kt
@@ -1,0 +1,183 @@
+package cc.unitmesh.devins.idea.agent.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cc.unitmesh.devins.idea.agent.IdeaCodingAgentViewModel
+import cc.unitmesh.devins.idea.agent.MessageInputState
+import kotlinx.coroutines.flow.distinctUntilChanged
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.Orientation
+import org.jetbrains.jewel.ui.component.*
+
+/**
+ * Main CodingAgent panel for IntelliJ IDEA.
+ * Uses Jewel theme for native integration.
+ */
+@Composable
+fun CodingAgentPanel(viewModel: IdeaCodingAgentViewModel) {
+    val inputState by viewModel.inputState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(JewelTheme.globalColors.panelBackground)
+    ) {
+        // Header
+        AgentHeader(
+            onNewConversation = { viewModel.onNewConversation() }
+        )
+
+        Divider(Orientation.Horizontal, modifier = Modifier.fillMaxWidth().height(1.dp))
+
+        // Message list
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            if (viewModel.renderer.timeline.isEmpty() && !viewModel.isExecuting) {
+                EmptyStateMessage()
+            } else {
+                AgentMessageList(
+                    renderer = viewModel.renderer,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+
+        Divider(Orientation.Horizontal, modifier = Modifier.fillMaxWidth().height(1.dp))
+
+        // Input area
+        AgentInput(
+            inputState = inputState,
+            isExecuting = viewModel.isExecuting,
+            onInputChanged = { viewModel.onInputChanged(it) },
+            onSubmit = { viewModel.executeTask(it) },
+            onStop = { viewModel.cancelTask() }
+        )
+    }
+}
+
+@Composable
+private fun AgentHeader(onNewConversation: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "CodingAgent",
+            style = JewelTheme.defaultTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp
+            )
+        )
+
+        IconButton(onClick = onNewConversation) {
+            Text("+", style = JewelTheme.defaultTextStyle)
+        }
+    }
+}
+
+@Composable
+private fun EmptyStateMessage() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "🤖 CodingAgent",
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Describe your coding task to get started!",
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontSize = 14.sp,
+                    color = JewelTheme.globalColors.text.info
+                )
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Commands: /clear, /help",
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontSize = 12.sp,
+                    color = JewelTheme.globalColors.text.info
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun AgentInput(
+    inputState: MessageInputState,
+    isExecuting: Boolean,
+    onInputChanged: (String) -> Unit,
+    onSubmit: (String) -> Unit,
+    onStop: () -> Unit
+) {
+    val textFieldState = rememberTextFieldState()
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { textFieldState.text.toString() }
+            .distinctUntilChanged()
+            .collect { onInputChanged(it) }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextField(
+            state = textFieldState,
+            placeholder = { Text("Describe your coding task...") },
+            modifier = Modifier
+                .weight(1f)
+                .onPreviewKeyEvent { keyEvent ->
+                    if (keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown && !isExecuting) {
+                        val text = textFieldState.text.toString()
+                        if (text.isNotBlank()) {
+                            onSubmit(text)
+                            textFieldState.edit { replace(0, length, "") }
+                        }
+                        true
+                    } else false
+                },
+            enabled = !isExecuting
+        )
+
+        if (isExecuting) {
+            DefaultButton(onClick = onStop) { Text("Stop") }
+        } else {
+            DefaultButton(
+                onClick = {
+                    val text = textFieldState.text.toString()
+                    if (text.isNotBlank()) {
+                        onSubmit(text)
+                        textFieldState.edit { replace(0, length, "") }
+                    }
+                },
+                enabled = inputState is MessageInputState.Enabled
+            ) { Text("Send") }
+        }
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/MessageItems.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/MessageItems.kt
@@ -1,0 +1,176 @@
+package cc.unitmesh.devins.idea.agent.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cc.unitmesh.devins.idea.agent.TokenInfo
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.markdown.Markdown
+import org.jetbrains.jewel.markdown.MarkdownBlock
+import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
+
+/**
+ * Message item component for displaying user or assistant messages.
+ */
+@Composable
+fun MessageItem(
+    content: String,
+    isUser: Boolean,
+    tokenInfo: TokenInfo? = null,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(4.dp))
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(8.dp)
+        ) {
+            Column {
+                if (isUser) {
+                    Text(
+                        text = content,
+                        style = JewelTheme.defaultTextStyle.copy(
+                            fontFamily = FontFamily.Monospace
+                        )
+                    )
+                } else {
+                    // Render markdown for assistant messages
+                    val processor = remember { MarkdownProcessor() }
+                    val blocks = remember(content) { processor.processMarkdownDocument(content) }
+                    Markdown(blocks = blocks, modifier = Modifier.fillMaxWidth())
+                }
+
+                // Token info for assistant messages
+                if (!isUser && tokenInfo != null && tokenInfo.totalTokens > 0) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "${tokenInfo.inputTokens} + ${tokenInfo.outputTokens} (${tokenInfo.totalTokens} tokens)",
+                        style = JewelTheme.defaultTextStyle.copy(
+                            fontSize = 10.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = JewelTheme.globalColors.text.info
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Streaming message item for displaying in-progress responses.
+ */
+@Composable
+fun StreamingMessageItem(
+    content: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(4.dp))
+            .background(JewelTheme.globalColors.panelBackground)
+            .padding(12.dp)
+    ) {
+        Column {
+            if (content.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                val processor = remember { MarkdownProcessor() }
+                val blocks = remember(content) { processor.processMarkdownDocument(content) }
+                Markdown(blocks = blocks, modifier = Modifier.fillMaxWidth())
+            }
+        }
+    }
+}
+
+/**
+ * Task completed item for displaying task completion status.
+ */
+@Composable
+fun TaskCompletedItem(
+    success: Boolean,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (success) JewelTheme.globalColors.panelBackground
+                else JewelTheme.globalColors.panelBackground
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = if (success) "✓" else "⚠",
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = if (success) JewelTheme.globalColors.text.info
+                           else JewelTheme.globalColors.text.error
+                )
+            )
+            Text(
+                text = message,
+                style = JewelTheme.defaultTextStyle.copy(
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 10.sp
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Error item for displaying error messages.
+ */
+@Composable
+fun ErrorItem(
+    error: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(4.dp))
+            .background(JewelTheme.globalColors.panelBackground)
+            .padding(8.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "⚠",
+                style = JewelTheme.defaultTextStyle.copy(
+                    color = JewelTheme.globalColors.text.error
+                )
+            )
+            Text(
+                text = error,
+                style = JewelTheme.defaultTextStyle.copy(
+                    color = JewelTheme.globalColors.text.error
+                )
+            )
+        }
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/ToolCallItems.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/agent/ui/ToolCallItems.kt
@@ -1,0 +1,151 @@
+package cc.unitmesh.devins.idea.agent.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cc.unitmesh.devins.idea.agent.ToolCallInfo
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Text
+
+@Composable
+fun ToolCallItem(
+    toolName: String,
+    details: String?,
+    success: Boolean? = null,
+    summary: String? = null,
+    output: String? = null,
+    executionTimeMs: Long? = null,
+    onExpand: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(success == false) }
+    LaunchedEffect(expanded) { if (expanded) onExpand() }
+    val isExecuting = success == null
+
+    Box(modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp))
+        .background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(
+                    indication = null, interactionSource = remember { MutableInteractionSource() }
+                ) { if (details != null || output != null) expanded = !expanded },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = when { isExecuting -> "▶"; success == true -> "✓"; else -> "✗" },
+                    style = JewelTheme.defaultTextStyle.copy(
+                        color = when { isExecuting -> JewelTheme.globalColors.text.info
+                            success == true -> JewelTheme.globalColors.text.info
+                            else -> JewelTheme.globalColors.text.error }))
+                Text(text = toolName, style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Bold),
+                    modifier = Modifier.weight(1f))
+                if (summary != null) {
+                    Text(text = "→ $summary", style = JewelTheme.defaultTextStyle.copy(
+                        color = when (success) { true -> JewelTheme.globalColors.text.info
+                            false -> JewelTheme.globalColors.text.error
+                            else -> JewelTheme.globalColors.text.normal }))
+                }
+                if (executionTimeMs != null && executionTimeMs > 0) {
+                    Text(text = "${executionTimeMs}ms", style = JewelTheme.defaultTextStyle.copy(
+                        fontSize = 10.sp, color = JewelTheme.globalColors.text.info))
+                }
+                if (details != null || output != null) {
+                    Text(text = if (expanded) "▲" else "▼",
+                        style = JewelTheme.defaultTextStyle.copy(color = JewelTheme.globalColors.text.info))
+                }
+            }
+            AnimatedVisibility(visible = expanded, enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()) {
+                Column {
+                    if (details != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(text = "Parameters:", style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Medium))
+                        Box(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp))
+                            .background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+                            Text(text = details, style = JewelTheme.defaultTextStyle.copy(fontFamily = FontFamily.Monospace))
+                        }
+                    }
+                    if (output != null) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(text = "Output:", style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Medium))
+                        Box(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp))
+                            .background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+                            Text(text = output, style = JewelTheme.defaultTextStyle.copy(fontFamily = FontFamily.Monospace))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CurrentToolCallItem(toolCall: ToolCallInfo, modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp))
+        .background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "⏳", style = JewelTheme.defaultTextStyle)
+            Text(text = toolCall.toolName, style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Bold))
+            Text(text = toolCall.description, style = JewelTheme.defaultTextStyle.copy(color = JewelTheme.globalColors.text.info))
+        }
+    }
+}
+
+@Composable
+fun TerminalOutputItem(
+    command: String, output: String, exitCode: Int, executionTimeMs: Long,
+    onExpand: () -> Unit = {}, modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(exitCode != 0) }
+    LaunchedEffect(expanded) { if (expanded) onExpand() }
+    val isSuccess = exitCode == 0
+
+    Box(modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp))
+        .background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(
+                    indication = null, interactionSource = remember { MutableInteractionSource() }
+                ) { expanded = !expanded },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(text = if (isSuccess) "✓" else "✗",
+                    style = JewelTheme.defaultTextStyle.copy(
+                        color = if (isSuccess) JewelTheme.globalColors.text.info else JewelTheme.globalColors.text.error))
+                Text(text = "Exit $exitCode",
+                    style = JewelTheme.defaultTextStyle.copy(fontWeight = FontWeight.Medium,
+                        color = if (isSuccess) JewelTheme.globalColors.text.info else JewelTheme.globalColors.text.error),
+                    modifier = Modifier.weight(1f))
+                Text(text = "${executionTimeMs}ms",
+                    style = JewelTheme.defaultTextStyle.copy(fontSize = 10.sp, color = JewelTheme.globalColors.text.info))
+                Text(text = if (expanded) "▲" else "▼",
+                    style = JewelTheme.defaultTextStyle.copy(color = JewelTheme.globalColors.text.info))
+            }
+            AnimatedVisibility(visible = expanded && output.isNotEmpty(),
+                enter = expandVertically() + fadeIn(), exit = shrinkVertically() + fadeOut()) {
+                Box(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+                    .clip(RoundedCornerShape(4.dp)).background(JewelTheme.globalColors.panelBackground).padding(8.dp)) {
+                    Text(text = output, style = JewelTheme.defaultTextStyle.copy(fontFamily = FontFamily.Monospace))
+                }
+            }
+        }
+    }
+}
+

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/AutoDevToolWindowFactory.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/AutoDevToolWindowFactory.kt
@@ -7,6 +7,8 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import cc.unitmesh.devins.idea.services.CoroutineScopeHolder
+import cc.unitmesh.devins.idea.agent.IdeaCodingAgentViewModel
+import cc.unitmesh.devins.idea.agent.ui.CodingAgentPanel
 import org.jetbrains.jewel.bridge.addComposeTab
 
 /**
@@ -22,20 +24,23 @@ class AutoDevToolWindowFactory : ToolWindowFactory {
     }
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        createChatPanel(project, toolWindow)
+        createAgentPanel(project, toolWindow)
     }
 
     override fun shouldBeAvailable(project: Project): Boolean = true
 
-    private fun createChatPanel(project: Project, toolWindow: ToolWindow) {
+    private fun createAgentPanel(project: Project, toolWindow: ToolWindow) {
         val coroutineScope = project.service<CoroutineScopeHolder>()
-            .createScope("AutoDevChatViewModel")
+            .createScope("IdeaCodingAgentViewModel")
 
-        val viewModel = AutoDevChatViewModel(coroutineScope)
+        val viewModel = IdeaCodingAgentViewModel(
+            project = project,
+            coroutineScope = coroutineScope
+        )
         Disposer.register(toolWindow.disposable, viewModel)
 
-        toolWindow.addComposeTab("Chat") {
-            AutoDevChatApp(viewModel)
+        toolWindow.addComposeTab("Agent") {
+            CodingAgentPanel(viewModel)
         }
     }
 }

--- a/mpp-idea/src/test/kotlin/cc/unitmesh/devins/idea/agent/IdeaCodingAgentViewModelTest.kt
+++ b/mpp-idea/src/test/kotlin/cc/unitmesh/devins/idea/agent/IdeaCodingAgentViewModelTest.kt
@@ -1,0 +1,148 @@
+package cc.unitmesh.devins.idea.agent
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for IdeaCodingAgentViewModel.
+ * Note: These tests are limited since we don't have a mock Project instance.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class IdeaCodingAgentViewModelTest {
+
+    @Test
+    fun `IdeaAgentRenderer should add user message correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.addUserMessage("Hello, World!")
+        
+        assertEquals(1, renderer.timeline.size)
+        val item = renderer.timeline[0] as TimelineItem.MessageItem
+        assertTrue(item.isUser)
+        assertEquals("Hello, World!", item.content)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should add assistant message correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.addAssistantMessage("I'm here to help!")
+        
+        assertEquals(1, renderer.timeline.size)
+        val item = renderer.timeline[0] as TimelineItem.MessageItem
+        assertFalse(item.isUser)
+        assertEquals("I'm here to help!", item.content)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should handle streaming correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.startStreaming()
+        assertTrue(renderer.isProcessing)
+        assertEquals("", renderer.currentStreamingOutput)
+        
+        renderer.appendStreamingContent("Hello ")
+        renderer.appendStreamingContent("World!")
+        assertEquals("Hello World!", renderer.currentStreamingOutput)
+        
+        renderer.endStreaming()
+        assertFalse(renderer.isProcessing)
+        assertEquals("", renderer.currentStreamingOutput)
+        assertEquals(1, renderer.timeline.size)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should handle tool calls correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.startToolCall("ReadFile", "Reading configuration", "config.json")
+        
+        assertEquals(1, renderer.timeline.size)
+        val item = renderer.timeline[0] as TimelineItem.ToolCallItem
+        assertEquals("ReadFile", item.toolName)
+        assertEquals(null, item.success) // Still executing
+        
+        renderer.completeToolCall(true, "Read 100 bytes", "file content...", 50)
+        
+        val updatedItem = renderer.timeline[0] as TimelineItem.ToolCallItem
+        assertTrue(updatedItem.success == true)
+        assertEquals("Read 100 bytes", updatedItem.summary)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should handle errors correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.addError("Something went wrong")
+        
+        assertEquals("Something went wrong", renderer.errorMessage)
+        assertEquals(1, renderer.timeline.size)
+        val item = renderer.timeline[0] as TimelineItem.ErrorItem
+        assertEquals("Something went wrong", item.error)
+        
+        renderer.clearError()
+        assertEquals(null, renderer.errorMessage)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should clear all state`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.addUserMessage("Test")
+        renderer.startStreaming()
+        renderer.appendStreamingContent("Streaming...")
+        renderer.addError("Error")
+        
+        renderer.clear()
+        
+        assertTrue(renderer.timeline.isEmpty())
+        assertEquals("", renderer.currentStreamingOutput)
+        assertFalse(renderer.isProcessing)
+        assertEquals(null, renderer.errorMessage)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should add task complete item`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.addTaskComplete(true, "Task completed successfully in 3 iterations")
+        
+        assertEquals(1, renderer.timeline.size)
+        val item = renderer.timeline[0] as TimelineItem.TaskCompleteItem
+        assertTrue(item.success)
+        assertEquals("Task completed successfully in 3 iterations", item.message)
+        assertFalse(renderer.isProcessing)
+    }
+
+    @Test
+    fun `IdeaAgentRenderer should force stop correctly`() {
+        val renderer = IdeaAgentRenderer()
+        
+        renderer.startStreaming()
+        renderer.appendStreamingContent("In progress...")
+        renderer.startToolCall("SomeTask", "Doing something", null)
+        
+        renderer.forceStop()
+        
+        assertEquals("", renderer.currentStreamingOutput)
+        assertEquals(null, renderer.currentToolCall)
+        assertFalse(renderer.isProcessing)
+    }
+
+    @Test
+    fun `TokenInfo should calculate total correctly`() {
+        val tokenInfo = TokenInfo(inputTokens = 100, outputTokens = 50)
+        
+        assertEquals(150, tokenInfo.totalTokens)
+    }
+}
+


### PR DESCRIPTION
## Summary

This PR implements the CodingAgent UI for the mpp-idea module using IntelliJ's Jewel theme, mirroring the functionality in mpp-ui but adapted for native IntelliJ IDEA integration.

## Changes

### New Files

#### Core Model & Renderer
- **`IdeaAgentRenderer.kt`** - Timeline state management
  - `TimelineItem` sealed class with variants: MessageItem, ToolCallItem, ErrorItem, TaskCompleteItem, TerminalOutputItem
  - `TokenInfo` and `ToolCallInfo` data classes
  - Streaming output and tool call state management

#### ViewModel
- **`IdeaCodingAgentViewModel.kt`** - Agent execution and UI state management
  - `MessageInputState` sealed class (Disabled, Enabled, Sending, SendFailed)
  - Task execution with cancellation support
  - Built-in commands (`/clear`, `/help`)
  - Simulated agent execution (pending mpp-core integration)

#### UI Components (Jewel Theme)
- **`CodingAgentPanel.kt`** - Main panel with header, message list, and input area
- **`AgentMessageList.kt`** - Timeline display with auto-scroll functionality
- **`MessageItems.kt`** - Message, streaming, task complete, and error displays with Markdown support
- **`ToolCallItems.kt`** - Tool call and terminal output with expand/collapse

### Modified Files
- **`AutoDevToolWindowFactory.kt`** - Updated to use `CodingAgentPanel`
- **`build.gradle.kts`** - Added required dependencies (kotlinx-datetime, kotlinx-coroutines-test, junit-jupiter)

### Tests
- **`IdeaCodingAgentViewModelTest.kt`** - Unit tests for `IdeaAgentRenderer`

## Architecture

```
mpp-idea/
├── agent/
│   ├── IdeaAgentRenderer.kt      # Timeline state (matches mpp-ui ComposeRenderer API)
│   ├── IdeaCodingAgentViewModel.kt
│   └── ui/
│       ├── CodingAgentPanel.kt   # Main Compose panel
│       ├── AgentMessageList.kt   # Timeline display
│       ├── MessageItems.kt       # Message rendering
│       └── ToolCallItems.kt      # Tool call rendering
└── toolwindow/
    └── AutoDevToolWindowFactory.kt
```

## Features

- ✅ Timeline display with user/assistant messages
- ✅ Markdown rendering for assistant messages
- ✅ Tool call display with expand/collapse
- ✅ Streaming output support
- ✅ Error display
- ✅ Task completion status
- ✅ Terminal output display
- ✅ Built-in commands (`/clear`, `/help`)
- ✅ Auto-scroll behavior
- ⏳ Actual LLM integration (pending mpp-core integration)

## Future Work

1. Integrate with mpp-core's `CodingAgent` for actual LLM execution
2. Add LLM configuration UI
3. Add MCP tools status bar (similar to mpp-ui's `ToolLoadingStatusBar`)

## Screenshots

_To be added after testing in IntelliJ IDEA 252+_

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Agent panel to the tool window, replacing the chat interface
  * Introduced a timeline-based chat display showing messages, tool executions, terminal outputs, and task completion status
  * Added real-time streaming content display during agent execution
  * Implemented tool call tracking with execution details and results
  * Added error handling and display within the conversation interface

* **Tests**
  * Added unit tests for agent renderer functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->